### PR TITLE
Fix a bug that caused uncompilable code to be generated

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/DefaultValueProviders.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/DefaultValueProviders.kt
@@ -85,6 +85,10 @@ class DefaultValueProviders(private val types: Types) {
                         val prov = it.typeMirror as DeclaredType
                         val prop = property.typeMirror as DeclaredType
 
+                        if (prop.typeArguments.size != prov.typeArguments.size) {
+                            return@filter false
+                        }
+
                         // Then all type arguments must match
                         prop.typeArguments.zip(prov.typeArguments) { propTypeArg, provTypeArg ->
                             if (types.isAssignable(propTypeArg, provTypeArg)) {

--- a/tests/src/main/kotlin/se/ansman/kotshi/ClassWithGenericDefaults.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/ClassWithGenericDefaults.kt
@@ -1,0 +1,20 @@
+package se.ansman.kotshi
+
+@JsonSerializable
+data class ClassWithGenericDefaults(
+        @JsonDefaultValue
+        val generic2: Generic2<String?, Int?>
+) {
+
+    open class Generic2<out T1, out T2>(val t1: T1, val t2: T2)
+    class Generic1<out T>(t1: T, t2: String?) : Generic2<T, String?>(t1, t2)
+
+    companion object {
+        @JsonDefaultValue
+        fun <T> provideGeneric1Default(): Generic1<T?> = Generic1(null, null)
+
+        @JsonDefaultValue
+        fun <T1, T2> provideGeneric2Default(): Generic2<T1?, T2?> = Generic2(null, null)
+    }
+
+}


### PR DESCRIPTION
The bug could cause an invalid provider to be picked if there was a
provider that provides a subclass with fewer generic type parameters
existed.

So for example if you had a property of the type `Map<String, String>`
and a subclass to map called `IntMap<T> : Map<Int, T>` and a generic
provider for that subclass then that provider would be used and thus the
generated code would not compile.