### PR TITLE
Read object opening before initializing locals.

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -286,6 +286,7 @@ class AdaptersProcessingStep(
                 .addIf("reader.peek() == \$T.NULL", JsonReader.Token::class.java) {
                     addStatement("return reader.nextNull()")
                 }
+                .addStatement("reader.beginObject()")
                 .apply {
                     for (property in properties) {
                         val variableType = property.variableType()
@@ -295,7 +296,6 @@ class AdaptersProcessingStep(
                         }
                     }
                 }
-                .addStatement("reader.beginObject()")
                 .addWhile("reader.hasNext()") {
                     addSwitch("reader.selectName(\$N)", optionsField) {
                         properties.forEachIndexed { index, property ->


### PR DESCRIPTION
This allows the adapter to fail sooner if the JSON is not actually an object.