### PR TITLE
When writing null, perform an an early return.

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -222,11 +222,12 @@ class AdaptersProcessingStep(
                     .addException(IOException::class.java)
                     .addParameter(JsonWriter::class.java, "writer")
                     .addParameter(TypeName.get(type), "value")
-                    .addIfElse("value == null") {
+                    .addIf("value == null") {
                         addStatement("writer.nullValue()")
+                        addStatement("return")
                     }
-                    .addElse {
-                        addStatement("writer.beginObject()")
+                    .addStatement("writer.beginObject()")
+                    .apply {
                         for (property in properties) {
                             addStatement("writer.name(\$S)", property.jsonName)
                             val getter = if (property.getter != null) {


### PR DESCRIPTION
This saves emitting a jump to the end of the method only to return and visually reduces nesting.