### PR TITLE
Eliminate superfluous null check on allowed-nullable values.

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -385,8 +385,8 @@ class AdaptersProcessingStep(
                             addStatement("stringBuilder = \$T.appendNullableError(stringBuilder, \$S)", KotshiUtils::class.java, property.name)
                         }
 
-                        addIf(check) {
-                            if (defaultValueProvider != null) {
+                        if (defaultValueProvider != null) {
+                            addIf(check) {
                                 // We require a temp var if the variable is a primitive and we allow the provider to return null
                                 val requiresTmpVar = variableType.isPrimitive && defaultValueProvider.isNullable
                                 val variableName = if (requiresTmpVar) "${property.name}Default" else property.name
@@ -419,7 +419,9 @@ class AdaptersProcessingStep(
                                     addStatement("${property.name} = $variableName")
                                 }
 
-                            } else if (!property.isNullable) {
+                            }
+                        } else if (!property.isNullable) {
+                            addIf(check) {
                                 appendError()
                             }
                         }


### PR DESCRIPTION
Before:
```java
if (!aBooleanIsSet) {
  stringBuilder = KotshiUtils.appendNullableError(stringBuilder, "aBoolean");
}
if (aNullableBoolean == null) {
}
if (!aByteIsSet) {
  stringBuilder = KotshiUtils.appendNullableError(stringBuilder, "aByte");
}
```
After:
```java
if (!aBooleanIsSet) {
  stringBuilder = KotshiUtils.appendNullableError(stringBuilder, "aBoolean");
}
if (!aByteIsSet) {
  stringBuilder = KotshiUtils.appendNullableError(stringBuilder, "aByte");
}
```