### PR TITLE
Remove explicit null check for boxed primitives in writer.

### DIFF
--- a/api/src/main/kotlin/se/ansman/kotshi/KotshiUtils.kt
+++ b/api/src/main/kotlin/se/ansman/kotshi/KotshiUtils.kt
@@ -74,7 +74,13 @@ object KotshiUtils {
     fun JsonWriter.byteValue(byte: Byte): JsonWriter = value(byte.toInt() and 0xff)
 
     @JvmStatic
+    fun JsonWriter.byteValue(byte: Byte?): JsonWriter = if (byte == null) nullValue() else byteValue(byte)
+
+    @JvmStatic
     fun JsonWriter.value(char: Char): JsonWriter = value(char.toString())
+
+    @JvmStatic
+    fun JsonWriter.value(char: Char?): JsonWriter = if (char == null) nullValue() else value(char)
 
     @JvmStatic
     private fun JsonReader.nextIntInRange(typeMessage: String, min: Int, max: Int): Int {

--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -252,17 +252,7 @@ class AdaptersProcessingStep(
                                             else -> throw AssertionError("Unknown type ${property.type}")
                                         }
 
-                                if (property.isNullable) {
-                                    addStatement("\$T ${property.name} = $getter", property.type)
-                                    addIfElse("${property.name} == null") {
-                                        addStatement("writer.nullValue()")
-                                    }
-                                    addElse {
-                                        writePrimitive("${property.name}")
-                                    }
-                                } else {
-                                    writePrimitive(getter)
-                                }
+                                writePrimitive(getter)
                             }
                         }
                         addStatement("writer.endObject()")


### PR DESCRIPTION
JavaWriter has Booean and Number overloads to value() which handle null. Add boxed overloads to custom Char and Byte handlers.