### PR TITLE
Wrap the JSON name strings onto one per-line.

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -91,8 +91,10 @@ class AdaptersProcessingStep(
                 ?.map { it as TypeVariableName }
                 ?: emptyList()
 
+        val stringArguments = Collections.nCopies(properties.size, "\$S").joinToString(",\n")
+        val jsonNames = properties.map { it.jsonName }
         val optionsField = FieldSpec.builder(JsonReader.Options::class.java, "OPTIONS", Modifier.FINAL, Modifier.STATIC, Modifier.PRIVATE)
-                .initializer("\$T.of(${properties.joinToString(", ") { "\"${it.jsonName}\"" }})", JsonReader.Options::class.java)
+                .initializer("\$[\$T.of(\n$stringArguments)\$]", JsonReader.Options::class.java, *jsonNames.toTypedArray())
                 .build()
         val typeSpec = TypeSpec.classBuilder(adapter)
                 .addTypeVariables(genericTypes)
@@ -430,7 +432,7 @@ class AdaptersProcessingStep(
                         }
                     }
                 }
-                .addStatement("return new \$T(\n${properties.joinToString(", \n") { it.name }})", type)
+                .addStatement("return new \$T(\n${properties.joinToString(",\n") { it.name }})", type)
                 .build()
     }
 }


### PR DESCRIPTION
This also uses the $S JavaPoet replacement to emit the string literals, as it will handle things like escaping, should some crazy person use a tab or emoji as their JSON key.

Before:
```java
private static final JsonReader.Options OPTIONS = JsonReader.Options.of("aBoolean", "aNullableBoolean", "aByte", ...);
```
After:
```java
private static final JsonReader.Options OPTIONS = JsonReader.Options.of(
    "aBoolean",
    "aNullableBoolean",
    "aByte",
    "nullableByte",
    "aChar",
    "nullableChar",
    "aShort",
    "nullableShort",
    "integer",
    "nullableInteger",
    "aLong",
    "nullableLong",
    "aFloat",
    "nullableFloat",
    "aDouble",
    "nullableDouble");
```