### PR TITLE
Migrate utils to top-level functions for true static methods.

### DIFF
--- a/api/src/main/kotlin/se/ansman/kotshi/KotshiUtils.kt
+++ b/api/src/main/kotlin/se/ansman/kotshi/KotshiUtils.kt
@@ -1,3 +1,10 @@
+/**
+ * A helper class for Kotshi.
+ *
+ * These functions should not be considered public and are subject to change without notice.
+ */
+@file:JvmName("KotshiUtils")
+
 package se.ansman.kotshi
 
 import com.squareup.moshi.JsonDataException
@@ -6,88 +13,70 @@ import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import java.lang.reflect.Proxy
 
-/**
- * A helper class for Kotshi.
- *
- * These functions should not be considered public and are subject to change without notice.
- */
-object KotshiUtils {
-    private const val ERROR_FORMAT = "Expected %s but was %s at path %s"
+private const val ERROR_FORMAT = "Expected %s but was %s at path %s"
 
-    @JvmStatic
-    fun appendNullableError(stringBuilder: StringBuilder?, propertyName: String): StringBuilder =
-            if (stringBuilder == null) {
-                StringBuilder("The following properties were null: ")
-            } else {
-                stringBuilder.append(", ")
-            }.append(propertyName)
+fun appendNullableError(stringBuilder: StringBuilder?, propertyName: String): StringBuilder =
+        if (stringBuilder == null) {
+            StringBuilder("The following properties were null: ")
+        } else {
+            stringBuilder.append(", ")
+        }.append(propertyName)
 
-    @JvmStatic
-    fun <T : Annotation> createJsonQualifierImplementation(annotationType: Class<T>): T {
-        if (!annotationType.isAnnotation) {
-            throw IllegalArgumentException("$annotationType must be an annotation.")
-        }
-        if (!annotationType.isAnnotationPresent(JsonQualifier::class.java)) {
-            throw IllegalArgumentException("$annotationType must have @JsonQualifier.")
-        }
-        if (annotationType.declaredMethods.isNotEmpty()) {
-            throw IllegalArgumentException("$annotationType must not declare methods.")
-        }
-        @Suppress("UNCHECKED_CAST")
-        return Proxy.newProxyInstance(annotationType.classLoader, arrayOf<Class<*>>(annotationType)) { proxy, method, args ->
-            when (method.name) {
-                "annotationType" -> annotationType
-                "equals" -> annotationType.isInstance(args[0])
-                "hashCode" -> 0
-                "toString" -> "@${annotationType.name}()"
-                else -> method.invoke(proxy, *args)
-            }
-        } as T
+fun <T : Annotation> createJsonQualifierImplementation(annotationType: Class<T>): T {
+    if (!annotationType.isAnnotation) {
+        throw IllegalArgumentException("$annotationType must be an annotation.")
     }
-
-    @JvmStatic
-    fun JsonReader.nextFloat(): Float {
-        val value = nextDouble().toFloat()
-        // Double check for infinity after float conversion; many doubles > Float.MAX
-        if (!isLenient && value.isInfinite()) {
-            throw JsonDataException("JSON forbids NaN and infinities: $value at path $path")
-        }
-        return value
+    if (!annotationType.isAnnotationPresent(JsonQualifier::class.java)) {
+        throw IllegalArgumentException("$annotationType must have @JsonQualifier.")
     }
-
-    @JvmStatic
-    fun JsonReader.nextByte(): Byte = nextIntInRange("a byte", -128, 255).toByte()
-
-    @JvmStatic
-    fun JsonReader.nextShort(): Short = nextIntInRange("a short", -32768, 32767).toShort()
-
-    @JvmStatic
-    fun JsonReader.nextChar(): Char {
-        val value = nextString()
-        if (value.length != 1) {
-            throw JsonDataException(ERROR_FORMAT.format("a char", value, path))
-        }
-        return value[0]
+    if (annotationType.declaredMethods.isNotEmpty()) {
+        throw IllegalArgumentException("$annotationType must not declare methods.")
     }
-
-    @JvmStatic
-    fun JsonWriter.byteValue(byte: Byte): JsonWriter = value(byte.toInt() and 0xff)
-
-    @JvmStatic
-    fun JsonWriter.byteValue(byte: Byte?): JsonWriter = if (byte == null) nullValue() else byteValue(byte)
-
-    @JvmStatic
-    fun JsonWriter.value(char: Char): JsonWriter = value(char.toString())
-
-    @JvmStatic
-    fun JsonWriter.value(char: Char?): JsonWriter = if (char == null) nullValue() else value(char)
-
-    @JvmStatic
-    private fun JsonReader.nextIntInRange(typeMessage: String, min: Int, max: Int): Int {
-        val value = nextInt()
-        if (value < min || value > max) {
-            throw JsonDataException(ERROR_FORMAT.format(typeMessage, value, path))
+    @Suppress("UNCHECKED_CAST")
+    return Proxy.newProxyInstance(annotationType.classLoader, arrayOf<Class<*>>(annotationType)) { proxy, method, args ->
+        when (method.name) {
+            "annotationType" -> annotationType
+            "equals" -> annotationType.isInstance(args[0])
+            "hashCode" -> 0
+            "toString" -> "@${annotationType.name}()"
+            else -> method.invoke(proxy, *args)
         }
-        return value
+    } as T
+}
+
+fun JsonReader.nextFloat(): Float {
+    val value = nextDouble().toFloat()
+    // Double check for infinity after float conversion; many doubles > Float.MAX
+    if (!isLenient && value.isInfinite()) {
+        throw JsonDataException("JSON forbids NaN and infinities: $value at path $path")
     }
+    return value
+}
+
+fun JsonReader.nextByte(): Byte = nextIntInRange("a byte", -128, 255).toByte()
+
+fun JsonReader.nextShort(): Short = nextIntInRange("a short", -32768, 32767).toShort()
+
+fun JsonReader.nextChar(): Char {
+    val value = nextString()
+    if (value.length != 1) {
+        throw JsonDataException(ERROR_FORMAT.format("a char", value, path))
+    }
+    return value[0]
+}
+
+fun JsonWriter.byteValue(byte: Byte): JsonWriter = value(byte.toInt() and 0xff)
+
+fun JsonWriter.byteValue(byte: Byte?): JsonWriter = if (byte == null) nullValue() else byteValue(byte)
+
+fun JsonWriter.value(char: Char): JsonWriter = value(char.toString())
+
+fun JsonWriter.value(char: Char?): JsonWriter = if (char == null) nullValue() else value(char)
+
+private fun JsonReader.nextIntInRange(typeMessage: String, min: Int, max: Int): Int {
+    val value = nextInt()
+    if (value < min || value > max) {
+        throw JsonDataException(ERROR_FORMAT.format(typeMessage, value, path))
+    }
+    return value
 }

--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -188,7 +188,7 @@ class AdaptersProcessingStep(
                             .apply {
                                 jsonQualifiers.forEachIndexed { index, qualifier ->
                                     if (index > 0) add(", ")
-                                    add("\$T.createJsonQualifierImplementation(\$T.class)", KotshiUtils::class.java, qualifier)
+                                    add("\$T.createJsonQualifierImplementation(\$T.class)", KOTSHI_UTILS, qualifier)
                                 }
                             }
                             .add("))")
@@ -260,8 +260,8 @@ class AdaptersProcessingStep(
                                             TypeName.DOUBLE,
                                             TypeName.SHORT,
                                             TypeName.BOOLEAN -> addStatement("writer.value($getter)")
-                                            TypeName.BYTE -> addStatement("\$T.byteValue(writer, $getter)", KotshiUtils::class.java)
-                                            TypeName.CHAR -> addStatement("\$T.value(writer, $getter)", KotshiUtils::class.java)
+                                            TypeName.BYTE -> addStatement("\$T.byteValue(writer, $getter)", KOTSHI_UTILS)
+                                            TypeName.CHAR -> addStatement("\$T.value(writer, $getter)", KOTSHI_UTILS)
                                             else -> throw AssertionError("Unknown type ${property.type}")
                                         }
 
@@ -332,10 +332,10 @@ class AdaptersProcessingStep(
                                             addStatement("\$L = reader.nextBoolean()", property.variableName())
                                         }
                                         TypeName.BYTE -> readPrimitive {
-                                            addStatement("\$L = \$T.nextByte(reader)", property.variableName(), KotshiUtils::class.java)
+                                            addStatement("\$L = \$T.nextByte(reader)", property.variableName(), KOTSHI_UTILS)
                                         }
                                         TypeName.SHORT -> readPrimitive {
-                                            addStatement("\$L = \$T.nextShort(reader)", property.variableName(), KotshiUtils::class.java)
+                                            addStatement("\$L = \$T.nextShort(reader)", property.variableName(), KOTSHI_UTILS)
                                         }
                                         TypeName.INT -> readPrimitive {
                                             addStatement("\$L = reader.nextInt()", property.variableName())
@@ -344,10 +344,10 @@ class AdaptersProcessingStep(
                                             addStatement("\$L = reader.nextLong()", property.variableName())
                                         }
                                         TypeName.CHAR -> readPrimitive {
-                                            addStatement("\$L = \$T.nextChar(reader)", property.variableName(), KotshiUtils::class.java)
+                                            addStatement("\$L = \$T.nextChar(reader)", property.variableName(), KOTSHI_UTILS)
                                         }
                                         TypeName.FLOAT -> readPrimitive {
-                                            addStatement("\$L = \$T.nextFloat(reader)", property.variableName(), KotshiUtils::class.java)
+                                            addStatement("\$L = \$T.nextFloat(reader)", property.variableName(), KOTSHI_UTILS)
                                         }
                                         TypeName.DOUBLE -> readPrimitive {
                                             addStatement("\$L = reader.nextDouble()", property.variableName())
@@ -393,7 +393,7 @@ class AdaptersProcessingStep(
                         }
 
                         fun appendError() {
-                            addStatement("stringBuilder = \$T.appendNullableError(stringBuilder, \$S)", KotshiUtils::class.java, property.name)
+                            addStatement("stringBuilder = \$T.appendNullableError(stringBuilder, \$S)", KOTSHI_UTILS, property.name)
                         }
 
                         if (defaultValueProvider != null) {

--- a/compiler/src/main/kotlin/se/ansman/kotshi/TypeNameExt.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/TypeNameExt.kt
@@ -1,9 +1,11 @@
 package se.ansman.kotshi
 
+import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
 
 val TYPE_NAME_STRING = TypeName.get(String::class.java)
+val KOTSHI_UTILS = ClassName.get("se.ansman.kotshi", "KotshiUtils")
 
 val TypeName.jvmDefault: String
     get() {


### PR DESCRIPTION
@JvmStatic methods in an 'object' actually generate two methods: instance ones with the actual method body and static ones which proxy to the instance ones through a singleton instance. Top-level functions are truly static in the bytecode allowing faster dispatch and halves the method count requirement of the class.