### PR TITLE
Do a direct continue inside switch cases.

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -308,7 +308,7 @@ class AdaptersProcessingStep(
                 .addWhile("reader.hasNext()") {
                     addSwitch("reader.selectName(\$N)", optionsField) {
                         properties.forEachIndexed { index, property ->
-                            addSwitchBranch("case \$L", index) {
+                            addSwitchBranch("\$L", index, terminator = "continue") {
                                 if (property.shouldUseAdapter) {
                                     val adapterFieldName = generateAdapterFieldName(adapters.indexOf(property.adapterKey))
                                     addStatement("\$L = \$L.fromJson(reader)", property.variableName(), adapterFieldName)
@@ -357,7 +357,7 @@ class AdaptersProcessingStep(
                                 }
                             }
                         }
-                        addSwitchBranch("case -1") {
+                        addSwitchBranch("-1", terminator = "continue") {
                             addStatement("reader.nextName()")
                             addStatement("reader.skipValue()")
                         }

--- a/compiler/src/main/kotlin/se/ansman/kotshi/MethodSpecExt.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/MethodSpecExt.kt
@@ -29,10 +29,12 @@ inline fun MethodSpec.Builder.addNextControlFlow(controlFlow: String,
  */
 inline fun MethodSpec.Builder.addSwitchBranch(branch: String,
                                               vararg args: Any,
+                                              /** Terminating statement. Pass null for fall-through. */
+                                              terminator: String? = "break",
                                               block: MethodSpec.Builder.() -> Unit): MethodSpec.Builder {
-    beginControlFlow("$branch:", *args)
+    beginControlFlow("case $branch:", *args)
     block()
-    addStatement("break")
+    terminator?.let { addStatement(it) }
     return endControlFlow()
 }
 


### PR DESCRIPTION
This avoids having to jump way ahead to the end of the switch bytecodes only to jump way back to the loop conditional.