### PR TITLE
Do not pass Moshi instance to adapter when not needed.

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/GeneratedAdapter.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/GeneratedAdapter.kt
@@ -1,0 +1,15 @@
+package se.ansman.kotshi
+
+import com.squareup.javapoet.ClassName
+
+data class GeneratedAdapter(
+    val className: ClassName,
+    val requiresMoshi: Boolean = true,
+    val requiresTypes: Boolean = false
+) {
+    init {
+        assert(!requiresTypes || requiresMoshi) {
+            "An adapter requiring types must also require a Moshi instance."
+        }
+    }
+}

--- a/compiler/src/main/kotlin/se/ansman/kotshi/KotshiProcessor.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/KotshiProcessor.kt
@@ -24,7 +24,7 @@ class KotshiProcessor : AbstractProcessor() {
     override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
 
     private fun initSteps(): Iterable<ProcessingStep> {
-        val adapters: MutableMap<TypeName, TypeName> = mutableMapOf()
+        val adapters: MutableMap<TypeName, GeneratedAdapter> = mutableMapOf()
         val defaultValueProviders = DefaultValueProviders(processingEnv.typeUtils)
         return listOf(
                 DefaultValuesProcessingStep(

--- a/tests/src/main/kotlin/se/ansman/kotshi/ClassWithWeirdNames.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/ClassWithWeirdNames.kt
@@ -8,5 +8,6 @@ data class ClassWithWeirdNames(
         val reader: Char,
         val adapter1: Byte,
         val adapter2: Int?,
-        val types: List<String>
+        val types: List<String>,
+        val moshi: String
 )


### PR DESCRIPTION
This also removes "types" and "moshi" from the allocated names as they are not used in methods where collisions could occur.

Closes #26.