### PR TITLE
Add IDE imls and Gradle's reports dir to ignores.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
+# Gradle
 .gradle
-local.properties
 build
+/reports
+
+# IntelliJ / Android Studio
 .idea
+*.iml
+local.properties
+
 hs_err*


### PR DESCRIPTION
If you have `--profile` enabled by default (which I do) and Gradle configuration fails it dumps things into `report/`. Also `*.iml`s from IDEA/AS shouldn't be commited since Gradle is the source of truth for build config.