### PR TITLE
Fix missing @JsonDefaultValue on custom annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ default value annotations (`@JsonDefaultValueString`, `@JsonDefaultValueInt` etc
         AnnotationTarget.PROPERTY_GETTER)
 @MustBeDocumented
 @Retention(AnnotationRetention.SOURCE)
+@JsonDefaultValue // Makes this annotation a custom default value annotation
 annotation class StringWithNA
 
 @JsonSerializable


### PR DESCRIPTION
The custom default value annotation `StringWithNA` was missing it's `@JsonDefaultValue` annotation.
I added it along with a comment to make it clear how important it is among the annotations boilerplate
(namely: `@Target`, `@MustBeDocumented` and `@Retention`)