### PR TITLE
Treat strings as primitive values and skip adapters per default

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -223,6 +223,8 @@ class AdaptersProcessingStep(
 
     private fun generateAdapterFieldName(index: Int): String = "adapter$index"
 
+    private val Property.jsonType get() = if (this.type.isBoxedPrimitive) this.type.unbox() else this.type
+
     private fun generateWriteMethod(type: TypeMirror,
                                     properties: Iterable<Property>,
                                     adapterKeys: Set<AdapterKey>): MethodSpec =
@@ -250,7 +252,7 @@ class AdaptersProcessingStep(
                             addStatement("$adapterName.toJson(writer, $getter)")
                         } else {
                             fun MethodSpec.Builder.writePrimitive(getter: String) =
-                                    when (if (property.type.isBoxedPrimitive) property.type.unbox() else property.type) {
+                                    when (property.jsonType) {
                                         TYPE_NAME_STRING,
                                         TypeName.INT,
                                         TypeName.LONG,
@@ -323,7 +325,7 @@ class AdaptersProcessingStep(
                                         }
                                     }
 
-                                    when (if (property.type.isBoxedPrimitive) property.type.unbox() else property.type) {
+                                    when (property.jsonType) {
                                         TYPE_NAME_STRING -> readPrimitive {
                                             addStatement("\$L = reader.nextString()", property.variableName())
                                         }

--- a/compiler/src/main/kotlin/se/ansman/kotshi/Property.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/Property.kt
@@ -46,7 +46,9 @@ class Property(
                 PrimitiveAdapters.DISABLED -> false
             }
 
-    val shouldUseAdapter: Boolean = !(type.isPrimitive || type.isBoxedPrimitive) || useAdaptersForPrimitives
+    val shouldUseAdapter: Boolean = useAdaptersForPrimitives ||
+            adapterKey.jsonQualifiers.isNotEmpty() ||
+            !(type.isPrimitive || type.isBoxedPrimitive || type == TYPE_NAME_STRING)
 
     init {
         if (shouldUseDefaultValue) {

--- a/tests/src/main/kotlin/se/ansman/kotshi/UseAdaptersPerDefault.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/UseAdaptersPerDefault.kt
@@ -2,6 +2,7 @@ package se.ansman.kotshi
 
 @JsonSerializable(useAdaptersForPrimitives = PrimitiveAdapters.ENABLED)
 data class UsingPrimitiveAdapterTestClass(
+        val aString: String,
         val aBoolean: Boolean,
         val aNullableBoolean: Boolean?,
         val aByte: Byte,
@@ -22,6 +23,7 @@ data class UsingPrimitiveAdapterTestClass(
 
 @JsonSerializable(useAdaptersForPrimitives = PrimitiveAdapters.DISABLED)
 data class NotUsingPrimitiveAdapterTestClass(
+        val aString: String,
         val aBoolean: Boolean,
         val aNullableBoolean: Boolean?,
         val aByte: Byte,

--- a/tests/src/test/kotlin/se/ansman/kotshi/TestPrimitiveAdapters.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/TestPrimitiveAdapters.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertEquals
 
 class TestPrimitiveAdapters {
     private lateinit var moshi: Moshi
+    private lateinit var stringAdapter: DelegateAdapter<String>
     private lateinit var booleanAdapter: DelegateAdapter<Boolean>
     private lateinit var byteAdapter: DelegateAdapter<Byte>
     private lateinit var charAdapter: DelegateAdapter<Char>
@@ -23,6 +24,7 @@ class TestPrimitiveAdapters {
     @Before
     fun setup() {
         val basicMoshi = Moshi.Builder().build()
+        stringAdapter = DelegateAdapter(basicMoshi.adapter(String::class.java))
         booleanAdapter = DelegateAdapter(basicMoshi.adapter(Boolean::class.java))
         byteAdapter = DelegateAdapter(basicMoshi.adapter(Byte::class.java))
         charAdapter = DelegateAdapter(basicMoshi.adapter(Char::class.java))
@@ -33,6 +35,7 @@ class TestPrimitiveAdapters {
         doubleAdapter = DelegateAdapter(basicMoshi.adapter(Double::class.java))
         moshi = Moshi.Builder()
                 .add(TestFactory.INSTANCE)
+                .add(String::class.java, stringAdapter)
                 .add(Boolean::class.javaPrimitiveType!!, booleanAdapter)
                 .add(Boolean::class.javaObjectType, booleanAdapter)
                 .add(Byte::class.javaPrimitiveType!!, byteAdapter)
@@ -55,6 +58,7 @@ class TestPrimitiveAdapters {
     @Test
     fun testDoesntCallAdapter() {
         testFormatting(json, NotUsingPrimitiveAdapterTestClass(
+                aString = "hello",
                 aBoolean = true,
                 aNullableBoolean = false,
                 aByte = -1,
@@ -71,6 +75,8 @@ class TestPrimitiveAdapters {
                 nullableFloat = 1337.5f,
                 aDouble = 4711.5,
                 nullableDouble = 1337.5))
+        assertEquals(0, stringAdapter.readCount)
+        assertEquals(0, stringAdapter.writeCount)
         assertEquals(0, booleanAdapter.readCount)
         assertEquals(0, booleanAdapter.writeCount)
         assertEquals(0, byteAdapter.readCount)
@@ -92,6 +98,7 @@ class TestPrimitiveAdapters {
     @Test
     fun testCallsAdapter() {
         testFormatting(json, UsingPrimitiveAdapterTestClass(
+                aString = "hello",
                 aBoolean = true,
                 aNullableBoolean = false,
                 aByte = -1,
@@ -108,6 +115,8 @@ class TestPrimitiveAdapters {
                 nullableFloat = 1337.5f,
                 aDouble = 4711.5,
                 nullableDouble = 1337.5))
+        assertEquals(1, stringAdapter.readCount)
+        assertEquals(1, stringAdapter.writeCount)
         assertEquals(2, booleanAdapter.readCount)
         assertEquals(2, booleanAdapter.writeCount)
         assertEquals(2, byteAdapter.readCount)
@@ -142,6 +151,7 @@ class TestPrimitiveAdapters {
 
     companion object {
         val json = """{
+            |  "aString": "hello",
             |  "aBoolean": true,
             |  "aNullableBoolean": false,
             |  "aByte": 255,


### PR DESCRIPTION
This closes #14 and #23