### PR TITLE
Handle properties names as java keywords such as default better

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/DefaultValueProviders.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/DefaultValueProviders.kt
@@ -111,7 +111,7 @@ class DefaultValueProviders(private val types: Types) {
             0 -> null
             1 -> applicable.first()
             else ->
-                throw ProcessingError("Multiple providers matches: ${applicable.map { it.accessor }}", property.field)
+                throw ProcessingError("Multiple providers matches: ${applicable.map { it.accessor }}", property.field ?: property.parameter)
         }
     }
 }

--- a/compiler/src/main/kotlin/se/ansman/kotshi/Property.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/Property.kt
@@ -15,11 +15,11 @@ class Property(
         globalConfig: GlobalConfig,
         enclosingClass: Element,
         val parameter: VariableElement,
-        val field: VariableElement,
+        val field: VariableElement?,
         val getter: ExecutableElement?
 ) {
 
-    val typeMirror: TypeMirror = field.asType()
+    val typeMirror: TypeMirror = field?.asType() ?: parameter.asType()
 
     val rawTypeMirror: TypeMirror by lazy { types.erasure(typeMirror) }
 
@@ -31,9 +31,9 @@ class Property(
 
     val adapterKey: AdapterKey = AdapterKey(type, parameter.getJsonQualifiers())
 
-    val name: CharSequence = field.simpleName
+    val name: CharSequence = field?.simpleName ?: parameter.simpleName
 
-    val jsonName: CharSequence = field.getAnnotation(Json::class.java)?.name
+    val jsonName: CharSequence = field?.getAnnotation(Json::class.java)?.name
             ?: parameter.getAnnotation(Json::class.java)?.name
             ?: name
 
@@ -51,6 +51,8 @@ class Property(
             !(type.isPrimitive || type.isBoxedPrimitive || type == TYPE_NAME_STRING)
 
     init {
+        require(getter != null || field != null)
+
         if (shouldUseDefaultValue) {
             if (adapterKey.isGeneric) {
                 throw ProcessingError("You cannot use default values on a generic type", parameter)

--- a/tests/src/main/kotlin/se/ansman/kotshi/ClassWithJavaKeyword.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/ClassWithJavaKeyword.kt
@@ -1,0 +1,17 @@
+package se.ansman.kotshi
+
+import com.squareup.moshi.Json
+
+@JsonSerializable
+data class ClassWithJavaKeyword(
+        @GetterName("getDefault")
+        @Json(name = "default")
+        val default: Boolean,
+        @GetterName("getInt")
+        @Json(name = "int")
+        val int: Int,
+        @GetterName("someCase")
+        @Json(name = "case")
+        @get:JvmName("someCase")
+        val case: Int
+)

--- a/tests/src/test/kotlin/se/ansman/kotshi/TestClassWithJavaKeyword.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/TestClassWithJavaKeyword.kt
@@ -1,0 +1,41 @@
+package se.ansman.kotshi
+
+import com.squareup.moshi.JsonWriter
+import okio.Buffer
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TestClassWithJavaKeyword {
+    private val adapter = KotshiClassWithJavaKeywordJsonAdapter()
+
+    @Test
+    fun reading() {
+        val json = """{
+            |  "default": true,
+            |  "int": 4711,
+            |  "case": 1337
+            |}""".trimMargin()
+
+        assertEquals(ClassWithJavaKeyword(true, 4711, 1337), adapter.fromJson(json))
+    }
+
+    @Test
+    fun writing() {
+        val expected = """{
+            |  "default": true,
+            |  "int": 4711,
+            |  "case": 1337
+            |}""".trimMargin()
+
+        val actual = Buffer()
+                .apply {
+                    adapter.toJson(JsonWriter.of(this)
+                            .apply {
+                                indent = "  "
+                            }, ClassWithJavaKeyword(true, 4711, 1337))
+                }
+                .readUtf8()
+        assertEquals(expected, actual)
+    }
+
+}


### PR DESCRIPTION
Here is a sample class that would fail compilation before this change:
```kotlin
data class Foo(@Json(name="default") @GetterName("getDefault") val default: Boolean)
```