### PR TITLE
Add support for @Transient modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ data class MyClass(
 ```
 The default value provider is allowed to return `null` but only if it's annotated with `@Nullable`.
 
+### Transient Values
+
+Fields marked with `@Transient` are not serialized. When constructing, the adapter supplies the specified
+[default value](#default-values) instead.
+
 Limitations
 ---
 Currently KAPT does not allow processing Kotlin files directly but rather the generated stubs. This has some downsides

--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -351,7 +351,7 @@ class AdaptersProcessingStep(
             }
             .addWhile("reader.hasNext()") {
                 addSwitch("reader.selectName(\$N)", optionsField) {
-                    properties.forEachIndexed { index, property ->
+                    properties.filterNot { it.isTransient }.forEachIndexed { index, property ->
                         addSwitchBranch("\$L", index, terminator = "continue") {
                             if (property.shouldUseAdapter) {
                                 val adapterFieldName = generateAdapterFieldName(adapters.indexOf(property.adapterKey))

--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -120,8 +120,10 @@ class AdaptersProcessingStep(
         nameAllocator.newName("stringBuilder")
         (0 until adapterKeys.size).forEach { nameAllocator.newName(generateAdapterFieldName(it)) }
 
-        val stringArguments = Collections.nCopies(properties.size, "\$S").joinToString(",\n")
-        val jsonNames = properties.map { it.jsonName }
+        val jsonNames = properties
+                .filterNot { it.isTransient }
+                .map { it.jsonName }
+        val stringArguments = Collections.nCopies(jsonNames.size, "\$S").joinToString(",\n")
         val optionsField = FieldSpec.builder(JsonReader.Options::class.java, "OPTIONS", Modifier.FINAL, Modifier.STATIC, Modifier.PRIVATE)
             .initializer("\$[\$T.of(\n$stringArguments)\$]", JsonReader.Options::class.java, *jsonNames.toTypedArray())
             .build()
@@ -264,7 +266,7 @@ class AdaptersProcessingStep(
             }
             .addStatement("writer.beginObject()")
             .addCode("\n")
-            .applyEach(properties) { property ->
+            .applyEach(properties.filterNot { it.isTransient }) { property ->
                 addStatement("writer.name(\$S)", property.jsonName)
                 val getter = if (property.getter != null) {
                     "value.${property.getter.simpleName}()"

--- a/compiler/src/main/kotlin/se/ansman/kotshi/DefaultValueProviders.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/DefaultValueProviders.kt
@@ -49,7 +49,9 @@ class DefaultValueProviders(private val types: Types) {
             ?: getPrimitiveAnnotation<Double, JsonDefaultValueDouble>(property) { CodeBlock.of("${it.value}") }
             ?: get(property, true)
             ?: get(property, false)
-            ?: throw ProcessingError("No default value provider found", property.parameter)
+            ?: throw ProcessingError("No default value provider found" +
+                    if (property.isTransient) { " (required for @Transient)" } else "",
+                    property.parameter)
     }
 
     private inline fun <reified T, reified A : Annotation> getPrimitiveAnnotation(property: Property, block: (A) -> CodeBlock): DefaultValueProvider? =

--- a/compiler/src/main/kotlin/se/ansman/kotshi/Property.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/Property.kt
@@ -6,6 +6,7 @@ import com.squareup.javapoet.TypeName
 import com.squareup.moshi.Json
 import javax.lang.model.element.Element
 import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.Modifier
 import javax.lang.model.element.VariableElement
 import javax.lang.model.type.TypeMirror
 import javax.lang.model.util.Types
@@ -37,6 +38,8 @@ class Property(
 
     val isNullable: Boolean = parameter.hasAnnotation("Nullable")
 
+    val isTransient: Boolean = field?.modifiers?.contains(Modifier.TRANSIENT) == true
+
     private val useAdaptersForPrimitives: Boolean =
         when (enclosingClass.getAnnotation(JsonSerializable::class.java).useAdaptersForPrimitives) {
             PrimitiveAdapters.DEFAULT -> globalConfig.useAdaptersForPrimitives
@@ -53,7 +56,8 @@ class Property(
     init {
         require(getter != null || field != null)
 
-        defaultValueProvider = if (defaultValueQualifier != null || parameter.hasAnnotation<JsonDefaultValue>()) {
+        defaultValueProvider = if (isTransient || defaultValueQualifier != null ||
+            parameter.hasAnnotation<JsonDefaultValue>()) {
             if (adapterKey.isGeneric) {
                 throw ProcessingError("You cannot use default values on a generic type", parameter)
             }

--- a/tests/src/main/kotlin/se/ansman/kotshi/ClassWithTransient.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/ClassWithTransient.kt
@@ -1,0 +1,15 @@
+package se.ansman.kotshi
+
+@JsonSerializable
+data class ClassWithTransient(
+    val value: String,
+    @Transient
+    val value2: String,
+    @Transient
+    val list: List<String> = listOf()
+) {
+    companion object {
+        @JsonDefaultValue
+        fun provideListDefault() = listOf<String>()
+    }
+}

--- a/tests/src/main/kotlin/se/ansman/kotshi/ClassWithTransient.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/ClassWithTransient.kt
@@ -2,8 +2,8 @@ package se.ansman.kotshi
 
 @JsonSerializable
 data class ClassWithTransient(
-    val value: String,
     @Transient
+    val value: String,
     val value2: String,
     @Transient
     val list: List<String> = listOf()

--- a/tests/src/test/kotlin/se/ansman/kotshi/TestTransientAdapters.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/TestTransientAdapters.kt
@@ -20,12 +20,12 @@ class TestTransientAdapters {
     @Test
     fun withValues() {
         val json = """{
-             |  "value": "string"
+             |  "value2": "string2"
              |}""".trimMargin()
 
         val expected = ClassWithTransient(
-            value = "string",
-            value2 = "",
+            value = "",
+            value2 = "string2",
             list = listOf())
 
         expected.testFormatting(json)
@@ -40,8 +40,8 @@ class TestTransientAdapters {
              |}""".trimMargin()
 
         val expected = ClassWithTransient(
-                value = "string",
-                value2 = "",
+                value = "",
+                value2 = "string2",
                 list = listOf())
 
         assertEquals(expected, moshi.adapter(ClassWithTransient::class.java).fromJson(json))

--- a/tests/src/test/kotlin/se/ansman/kotshi/TestTransientAdapters.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/TestTransientAdapters.kt
@@ -1,0 +1,63 @@
+package se.ansman.kotshi
+
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import okio.Buffer
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TestTransientAdapters {
+    private lateinit var moshi: Moshi
+
+    @Before
+    fun setup() {
+        moshi = Moshi.Builder()
+            .add(TestFactory.INSTANCE)
+            .build()
+    }
+
+    @Test
+    fun withValues() {
+        val json = """{
+             |  "value": "string"
+             |}""".trimMargin()
+
+        val expected = ClassWithTransient(
+            value = "string",
+            value2 = "",
+            list = listOf())
+
+        expected.testFormatting(json)
+    }
+
+    @Test
+    fun ignoreSupplied() {
+        val json = """{
+             |  "value": "string",
+             |  "value2": "string2",
+             |  "list": [ "string3" ]
+             |}""".trimMargin()
+
+        val expected = ClassWithTransient(
+                value = "string",
+                value2 = "",
+                list = listOf())
+
+        assertEquals(expected, moshi.adapter(ClassWithTransient::class.java).fromJson(json))
+    }
+
+    private inline fun <reified T> T.testFormatting(json: String) {
+        val adapter = moshi.adapter(T::class.java)
+        val actual = adapter.fromJson(json)
+        assertEquals(this, actual)
+        assertEquals(json, Buffer()
+            .apply {
+                JsonWriter.of(this).run {
+                    indent = "  "
+                    adapter.toJson(this, actual)
+                }
+            }
+            .readUtf8())
+    }
+}


### PR DESCRIPTION
Closes #78.

* Allows user to specify `@Transient` for a data class field.
* Transient fields are not output to JSON
* Transient field data in incoming JSON is ignored
* A `@JsonDefaultValue` must be supplied somehow (but `@JsonDefaultValue` need not be specified explicitly on the field itself)