### PR TITLE
Replace kotlin-stdlib-jre7 with kotlin-stdlib-jdk7.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ subprojects { project ->
 }
 
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.2.40'
 
     repositories {
         mavenCentral()
@@ -49,7 +49,7 @@ ext {
             junit         : 'junit:junit:4.12',
             truth         : 'com.google.truth:truth:0.30',
             compiletesting: 'com.google.testing.compile:compile-testing:0.10',
-            kotlin        : "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version",
+            kotlin        : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version",
             kotlin_junit  : "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version",
             moshi         : "com.squareup.moshi:moshi:1.5.0"
     ]


### PR DESCRIPTION
kotlin-stdlib-jre7 is deprecated.

Also updated Kotlin version to 1.2.40, which contains the deprecation warning.

Fixes https://github.com/ansman/kotshi/issues/83