### PR TITLE
extra if statement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,14 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        google()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.0.0'
-        classpath 'org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.8'
+        classpath 'org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.17'
     }
 }
 
@@ -26,6 +27,7 @@ allprojects {
 
     repositories {
         mavenCentral()
+        google()
     }
 
     idea {

--- a/compiler/src/main/kotlin/se/ansman/kotshi/FactoryProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/FactoryProcessingStep.kt
@@ -91,7 +91,10 @@ class FactoryProcessingStep(
                 .apply {
                     when {
                         genericAdapters.isEmpty() -> addCode(handleRegularAdapters(regularAdapters))
-                        regularAdapters.isEmpty() -> addCode(handleGenericAdapters(genericAdapters))
+                        regularAdapters.isEmpty() ->
+                            addIf("type instanceof \$T", ParameterizedType::class.java) {
+                                addCode(handleGenericAdapters(genericAdapters))
+                            }
                         else -> {
                             addIf("type instanceof \$T", ParameterizedType::class.java) {
                                 addCode(handleGenericAdapters(genericAdapters))


### PR DESCRIPTION
added if statement before creating generic adapters when there is no regular one. 

in case we don't have regular model and Kotshi generate adapter factory for our generic models only, the code will not check if the type is instance of a parameterized type and just tries to cast it, and will crash the app since Moshi will pass every type (even String which is not parameterized) to this factory.
