### PR TITLE
Make generated adapters and factories internal

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -156,6 +156,7 @@ class AdaptersProcessingStep(
             .build()
 
         val typeSpec = TypeSpec.classBuilder(adapterClassName)
+            .addModifiers(KModifier.INTERNAL)
             .addOriginatingElement(element)
             .maybeAddGeneratedAnnotation(elements, sourceVersion)
             .addTypeVariables(typeVariables)

--- a/compiler/src/main/kotlin/se/ansman/kotshi/FactoryProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/FactoryProcessingStep.kt
@@ -78,6 +78,7 @@ class FactoryProcessingStep(
 
         typeSpecBuilder
             .maybeAddGeneratedAnnotation(elements, sourceVersion)
+            .addModifiers(KModifier.INTERNAL)
             .addOriginatingElement(element)
 
         val typeParam = ParameterSpec.builder("type", Type::class)

--- a/tests/src/main/kotlin/se/ansman/kotshi/InternalClass.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/InternalClass.kt
@@ -1,0 +1,4 @@
+package se.ansman.kotshi
+
+@JsonSerializable
+internal data class InternalClass(val prop: String)


### PR DESCRIPTION
This might break things from some people but I doubt many people rely on accessing the generated adapters or factories from other modules.