### PR TITLE
Improve how to implement the factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,7 @@ data class Person(
 Then create a class that will be your factory:
 ```kotlin
 @KotshiJsonAdapterFactory
-abstract class ApplicationJsonAdapterFactory : JsonAdapter.Factory {
-    companion object {
-        val INSTANCE: ApplicationJsonAdapterFactory = KotshiApplicationJsonAdapterFactory
-    }
-}
+object ApplicationJsonAdapterFactory : JsonAdapter.Factory by KotshiApplicationJsonAdapterFactory
 ```
 
 Lastly just add the factory to your Moshi instance and you're all set:

--- a/api/src/main/kotlin/se/ansman/kotshi/KotshiJsonAdapterFactory.kt
+++ b/api/src/main/kotlin/se/ansman/kotshi/KotshiJsonAdapterFactory.kt
@@ -8,11 +8,7 @@ package se.ansman.kotshi
  * Example:
  * ```kotlin
  * @KotshiJsonAdapterFactory
- * abstract class ApplicationJsonAdapterFactory : JsonAdapter.Factory {
- *     companion object {
- *         val INSTANCE: ApplicationJsonAdapterFactory = KotshiApplicationJsonAdapterFactory
- *     }
- * }
+ * object ApplicationJsonAdapterFactory : JsonAdapter.Factory by KotshiApplicationJsonAdapterFactory
  * ```
  *
  * @param useAdaptersForPrimitives A flag to enable or disable the use of adapters on a module basis. Since using


### PR DESCRIPTION
Instead of having to make the factory abstract and have a static
INSTANCE field factories can now be an `object` that delegates the
adapter creation to the generated factory.

This was done previously but there was issues but those seems to have
been caused by SuperficialValidation.validateElement returning false for
the factory class in some cases. It doesn't seem like that call is
needed so now the generation has been simplified.