### PR TITLE
Fix a crash that can happen when using adapters from a library

### DIFF
--- a/api/src/main/kotlin/se/ansman/kotshi/KotshiUtils.kt
+++ b/api/src/main/kotlin/se/ansman/kotshi/KotshiUtils.kt
@@ -26,7 +26,8 @@ object KotshiUtils {
                 """.trimIndent())
 
     @JvmStatic
-    fun StringBuilder?.appendNullableError(propertyName: String, jsonName: String): StringBuilder =
+    @JvmOverloads
+    fun StringBuilder?.appendNullableError(propertyName: String, jsonName: String = propertyName): StringBuilder =
         if (this == null) {
             StringBuilder("The following properties were null: ")
         } else {


### PR DESCRIPTION
KotshiUtils was updated and was not binary compatible meaning Kotshi adapters in libraries would expect the old method for appending errors which does not exist on the new version.