### PR TITLE
Fix annotating generic types with an annotation

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/generators/DataClassAdapterGenerator.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/generators/DataClassAdapterGenerator.kt
@@ -133,9 +133,9 @@ class DataClassAdapterGenerator(
                 .initializer(CodeBlock.builder()
                     .add("«%N.adapter(", moshiParameter)
                     .add(adapterKey.asRuntimeType { typeVariableName ->
-                        val genericIndex = elementTypeSpec.typeVariables.indexOf(typeVariableName.notNull())
+                        val genericIndex = elementTypeSpec.typeVariables.indexOfFirst { it.name == typeVariableName.name }
                         if (genericIndex == -1) {
-                            throw ProcessingError("Element is generic but if an unknown type", element)
+                            throw ProcessingError("Element is generic but is of an unknown type", element)
                         } else {
                             CodeBlock.of("%N[$genericIndex]", typesParameter)
                         }

--- a/tests/src/main/kotlin/se/ansman/kotshi/GenericClass.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/GenericClass.kt
@@ -1,4 +1,11 @@
 package se.ansman.kotshi
 
+@Target(AnnotationTarget.TYPE)
+annotation class SomeTypeAnnotation
+
 @JsonSerializable
-data class GenericClass<out T : CharSequence, out C : Collection<T>>(val collection: C, val value: T)
+data class GenericClass<out T : CharSequence, out C : Collection<T>>(
+    val collection: C,
+    val value: T,
+    val valueWithTypeAnnotation: @SomeTypeAnnotation T
+)

--- a/tests/src/test/kotlin/se/ansman/kotshi/TestAdapterGeneration.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/TestAdapterGeneration.kt
@@ -63,7 +63,8 @@ class TestAdapterGeneration {
         |      "val1",
         |      "val2"
         |    ],
-        |    "value": "val3"
+        |    "value": "val3",
+        |    "valueWithTypeAnnotation": "val4"
         |  }
         |}""".trimMargin()
         val adapter = moshi.adapter(TestClass::class.java)
@@ -92,7 +93,7 @@ class TestAdapterGeneration {
             customName = "other_value",
             annotated = "Hello, World!",
             anotherAnnotated = "Hello, Other World!",
-            genericClass = GenericClass(listOf("val1", "val2"), "val3"))
+            genericClass = GenericClass(listOf("val1", "val2"), "val3", "val4"))
 
         assertEquals(expected, actual)
         assertEquals(json, Buffer()


### PR DESCRIPTION
This is required when using `@RawValue` on Android for example.