### PR TITLE
Reduce the number of adapters that are fetched

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/Property.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/Property.kt
@@ -30,7 +30,10 @@ class Property private constructor(
         ): Property {
             val name = parameter.name
             val type = parameter.type
-            val adapterKey = AdapterKey(type.notNull(), parameter.annotations.qualifiers(elements))
+            val adapterKey = AdapterKey(
+                type = type.copy(nullable = false, annotations = emptyList()),
+                jsonQualifiers = parameter.annotations.qualifiers(elements)
+            )
 
             val useAdaptersForPrimitives = when (enclosingClass.getAnnotation(JsonSerializable::class.java).useAdaptersForPrimitives) {
                 PrimitiveAdapters.DEFAULT -> globalConfig.useAdaptersForPrimitives

--- a/compiler/src/main/kotlin/se/ansman/kotshi/generators/DataClassAdapterGenerator.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/generators/DataClassAdapterGenerator.kt
@@ -83,6 +83,7 @@ class DataClassAdapterGenerator(
             .asSequence()
             .filter { it.shouldUseAdapter }
             .map { it.adapterKey }
+            .distinct()
             .generatePropertySpecs()
 
         primaryConstructor(FunSpec.constructorBuilder()
@@ -141,7 +142,7 @@ class DataClassAdapterGenerator(
                         }
                     })
                     .add(adapterKey.annotations())
-                    .add(")\n»")
+                    .add(")»")
                     .build())
                 .build()
         }


### PR DESCRIPTION
Type annotations should not be considered when comparing adapter keys since
they don't affect which adapter that is returned. Now the annotations
are ignored and fewer adapters are requested. The performance impact
will be miniscule however since Moshi caches adapters.