### PR TITLE
Allow specifying sealed class behavior for missing and invalid labels

### DIFF
--- a/api/src/main/kotlin/se/ansman/kotshi/Polymorphic.kt
+++ b/api/src/main/kotlin/se/ansman/kotshi/Polymorphic.kt
@@ -38,7 +38,7 @@ annotation class Polymorphic(
     val onInvalid: Fallback = Fallback.DEFAULT
 ) {
     /**
-     * Specifies what happens if the polymorphic label is invalid or missing.
+     * Specifies what happens if the polymorphic label is invalid or missing during parsing of a sealed class.
      */
     enum class Fallback {
         /**

--- a/api/src/main/kotlin/se/ansman/kotshi/Polymorphic.kt
+++ b/api/src/main/kotlin/se/ansman/kotshi/Polymorphic.kt
@@ -1,5 +1,7 @@
 package se.ansman.kotshi
 
+import com.squareup.moshi.JsonDataException
+
 /**
  * Annotation to be placed on a sealed class to describe how it should be parsed.
  *
@@ -26,9 +28,30 @@ package se.ansman.kotshi
  * data class HoldemHand(val hiddenCards: List<Card>) : HandOfCards()
  * ```
  *
- * @param labelKey The key in the json that describes which subtype the object should be decoded as.
+ * @param labelKey the key in the json that describes which subtype the object should be decoded as.
+ * @param onMissing defined what happens if [labelKey] is missing from the JSON.
+ * @param onInvalid defined what happens if [labelKey] is present but invalid (unknown).
  */
-annotation class Polymorphic(val labelKey: String)
+annotation class Polymorphic(
+    val labelKey: String,
+    val onMissing: Fallback = Fallback.DEFAULT,
+    val onInvalid: Fallback = Fallback.DEFAULT
+) {
+    /**
+     * Specifies what happens if the polymorphic label is invalid or missing.
+     */
+    enum class Fallback {
+        /**
+         * The default behavior which is to use the class annotated with [JsonDefaultValue] if it exists, otherwise
+         * it behaves like [FAIL].
+         */
+        DEFAULT,
+        /** Throw a [JsonDataException]. */
+        FAIL,
+        /** Return `null` */
+        NULL
+    }
+}
 
 /**
  * An annotation must be applied to subtypes of a sealed class to specify the value that represents the type.

--- a/tests/src/main/kotlin/se/ansman/kotshi/SealedClassOnInvalidFail.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/SealedClassOnInvalidFail.kt
@@ -1,0 +1,13 @@
+package se.ansman.kotshi
+
+@JsonSerializable
+@Polymorphic(labelKey = "type", onInvalid = Polymorphic.Fallback.FAIL)
+sealed class SealedClassOnInvalidFail {
+    @JsonSerializable
+    @PolymorphicLabel("type1")
+    data class Subclass1(val foo: String) : SealedClassOnInvalidFail()
+
+    @JsonSerializable
+    @JsonDefaultValue
+    object Default : SealedClassOnInvalidFail()
+}

--- a/tests/src/main/kotlin/se/ansman/kotshi/SealedClassOnInvalidNull.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/SealedClassOnInvalidNull.kt
@@ -1,0 +1,13 @@
+package se.ansman.kotshi
+
+@JsonSerializable
+@Polymorphic(labelKey = "type", onInvalid = Polymorphic.Fallback.NULL)
+sealed class SealedClassOnInvalidNull {
+    @JsonSerializable
+    @PolymorphicLabel("type1")
+    data class Subclass1(val foo: String) : SealedClassOnInvalidNull()
+
+    @JsonSerializable
+    @JsonDefaultValue
+    object Default : SealedClassOnInvalidNull()
+}

--- a/tests/src/main/kotlin/se/ansman/kotshi/SealedClassOnMissingFail.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/SealedClassOnMissingFail.kt
@@ -1,0 +1,13 @@
+package se.ansman.kotshi
+
+@JsonSerializable
+@Polymorphic(labelKey = "type", onMissing = Polymorphic.Fallback.FAIL)
+sealed class SealedClassOnMissingFail {
+    @JsonSerializable
+    @PolymorphicLabel("type1")
+    data class Subclass1(val foo: String) : SealedClassOnMissingFail()
+
+    @JsonSerializable
+    @JsonDefaultValue
+    object Default : SealedClassOnMissingFail()
+}

--- a/tests/src/main/kotlin/se/ansman/kotshi/SealedClassOnMissingNull.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/SealedClassOnMissingNull.kt
@@ -1,0 +1,13 @@
+package se.ansman.kotshi
+
+@JsonSerializable
+@Polymorphic(labelKey = "type", onMissing = Polymorphic.Fallback.NULL)
+sealed class SealedClassOnMissingNull {
+    @JsonSerializable
+    @PolymorphicLabel("type1")
+    data class Subclass1(val foo: String) : SealedClassOnMissingNull()
+
+    @JsonSerializable
+    @JsonDefaultValue
+    object Default : SealedClassOnMissingNull()
+}

--- a/tests/src/test/kotlin/se/ansman/kotshi/SealedClassFallbacks.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/SealedClassFallbacks.kt
@@ -1,0 +1,40 @@
+package se.ansman.kotshi
+
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.Moshi
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class SealedClassFallbacks {
+    private val moshi = Moshi.Builder().add(TestFactory).build()
+    private val a1 = moshi.adapter(SealedClassOnInvalidFail::class.java)
+    private val a2 = moshi.adapter(SealedClassOnInvalidNull::class.java)
+    private val a3 = moshi.adapter(SealedClassOnMissingFail::class.java)
+    private val a4 = moshi.adapter(SealedClassOnMissingNull::class.java)
+
+    @Test
+    fun invalid_fail() {
+        assertFailsWith<JsonDataException> { a1.fromJson("""{"type":"type2"}""") }
+        assertEquals(SealedClassOnInvalidFail.Default, a1.fromJson("{}"))
+    }
+
+    @Test
+    fun invalid_null() {
+        assertNull(a2.fromJson("""{"type":"type2"}"""))
+        assertEquals(SealedClassOnInvalidNull.Default, a2.fromJson("{}"))
+    }
+
+    @Test
+    fun missing_fail() {
+        assertFailsWith<JsonDataException> { a3.fromJson("{}") }
+        assertEquals(SealedClassOnMissingFail.Default, a3.fromJson("""{"type":"type2"}"""))
+    }
+
+    @Test
+    fun missing_null() {
+        assertNull(a4.fromJson("{}"))
+        assertEquals(SealedClassOnMissingNull.Default, a4.fromJson("""{"type":"type2"}"""))
+    }
+}


### PR DESCRIPTION
By default the default will be used if one exists otherwise parsing will
fail with a `JsonDataException`. There are no two additional fallback
modes. One will always fail parsing and one will return `null`.