### PR TITLE
Emit labels when serializing sealed class subtypes

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/AdaptersProcessingStep.kt
@@ -21,6 +21,7 @@ import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.Element
 import javax.lang.model.util.Elements
+import javax.lang.model.util.Types
 import javax.tools.Diagnostic
 
 class AdaptersProcessingStep(
@@ -29,6 +30,7 @@ class AdaptersProcessingStep(
     private val messager: Messager,
     override val filer: Filer,
     private val adapters: MutableList<GeneratedAdapter>,
+    private val types: Types,
     private val elements: Elements,
     private val sourceVersion: SourceVersion
 ) : KotshiProcessor.GeneratingProcessingStep() {
@@ -59,6 +61,7 @@ class AdaptersProcessingStep(
                 val generator = when {
                     metadata.isData -> DataClassAdapterGenerator(
                         classInspector = classInspector,
+                        types = types,
                         elements = elements,
                         element = typeElement,
                         metadata = metadata,
@@ -66,6 +69,7 @@ class AdaptersProcessingStep(
                     )
                     metadata.isEnum -> EnumAdapterGenerator(
                         classInspector = classInspector,
+                        types = types,
                         elements = elements,
                         element = typeElement,
                         metadata = metadata,
@@ -73,6 +77,7 @@ class AdaptersProcessingStep(
                     )
                     metadata.isObject -> ObjectAdapterGenerator(
                         classInspector = classInspector,
+                        types = types,
                         element = typeElement,
                         metadata = metadata,
                         elements = elements,
@@ -80,6 +85,7 @@ class AdaptersProcessingStep(
                     )
                     metadata.isSealed -> SealedClassAdapterGenerator(
                         classInspector = classInspector,
+                        types = types,
                         element = typeElement,
                         metadata = metadata,
                         elements = elements,

--- a/compiler/src/main/kotlin/se/ansman/kotshi/KotshiProcessor.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/KotshiProcessor.kt
@@ -18,11 +18,13 @@ import javax.lang.model.SourceVersion
 import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
 import javax.lang.model.util.Elements
+import javax.lang.model.util.Types
 
 @AutoService(Processor::class)
 @IncrementalAnnotationProcessor(AGGREGATING)
 class KotshiProcessor : AbstractProcessor() {
     private lateinit var elements: Elements
+    private lateinit var types: Types
     private lateinit var classInspector: ClassInspector
     private lateinit var steps: ImmutableList<out ProcessingStep>
 
@@ -37,6 +39,7 @@ class KotshiProcessor : AbstractProcessor() {
                 messager = processingEnv.messager,
                 filer = processingEnv.filer,
                 adapters = adapters,
+                types = types,
                 elements = processingEnv.elementUtils,
                 sourceVersion = processingEnv.sourceVersion
             ),
@@ -56,6 +59,7 @@ class KotshiProcessor : AbstractProcessor() {
     override fun init(processingEnv: ProcessingEnvironment) {
         super.init(processingEnv)
         elements = processingEnv.elementUtils
+        types = processingEnv.typeUtils
         classInspector = ElementsClassInspector.create(elements, processingEnv.typeUtils)
         steps = ImmutableList.copyOf(initSteps())
     }

--- a/compiler/src/main/kotlin/se/ansman/kotshi/generators/AdapterGenerator.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/generators/AdapterGenerator.kt
@@ -42,9 +42,11 @@ import javax.annotation.processing.Filer
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
 import javax.lang.model.util.Elements
+import javax.lang.model.util.Types
 
 abstract class AdapterGenerator(
     classInspector: ClassInspector,
+    protected val types: Types,
     protected val elements: Elements,
     protected val element: TypeElement,
     protected val metadata: ImmutableKmClass,

--- a/compiler/src/main/kotlin/se/ansman/kotshi/generators/EnumAdapterGenerator.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/generators/EnumAdapterGenerator.kt
@@ -15,14 +15,16 @@ import se.ansman.kotshi.jsonName
 import se.ansman.kotshi.nullable
 import javax.lang.model.element.TypeElement
 import javax.lang.model.util.Elements
+import javax.lang.model.util.Types
 
 class EnumAdapterGenerator(
     classInspector: ClassInspector,
+    types: Types,
     elements: Elements,
     element: TypeElement,
     metadata: ImmutableKmClass,
     globalConfig: GlobalConfig
-) : AdapterGenerator(classInspector, elements, element, metadata, globalConfig) {
+) : AdapterGenerator(classInspector, types, elements, element, metadata, globalConfig) {
     init {
         require(metadata.isEnum)
     }

--- a/compiler/src/main/kotlin/se/ansman/kotshi/generators/ObjectAdapterGenerator.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/generators/ObjectAdapterGenerator.kt
@@ -7,8 +7,6 @@ import com.squareup.kotlinpoet.jvm.throws
 import com.squareup.kotlinpoet.metadata.ImmutableKmClass
 import com.squareup.kotlinpoet.metadata.isObject
 import com.squareup.kotlinpoet.metadata.specs.ClassInspector
-import se.ansman.kotshi.Polymorphic
-import se.ansman.kotshi.PolymorphicLabel
 import se.ansman.kotshi.addControlFlow
 import se.ansman.kotshi.addElse
 import se.ansman.kotshi.addIfElse
@@ -40,15 +38,11 @@ class ObjectAdapterGenerator(
                     addStatement("%N.nullValue()", writerParameter)
                 }
                 .addElse {
-                    val label = element.getAnnotation(PolymorphicLabel::class.java)?.value
-                    val labelKey = types.asElement(element.superclass)?.getAnnotation(Polymorphic::class.java)?.labelKey
-                    if (label != null && labelKey != null) {
-                        addStatement("%N.beginObject()", writerParameter)
-                        addStatement("%N.name(%S).value(%S)", writerParameter, labelKey, label)
-                        addStatement("%N.endObject()", writerParameter)
-                    } else {
-                        addStatement("%N\n.beginObject()\n.endObject()", writerParameter)
+                    addStatement("%N.beginObject()", writerParameter)
+                    for ((key, value) in getPolymorphicLabels()) {
+                        addStatement("%N.name(%S).value(%S)", writerParameter, key, value)
                     }
+                    addStatement("%N.endObject()", writerParameter)
                 }
                 .build())
             .addFunction(FunSpec.builder("fromJson")

--- a/compiler/src/main/kotlin/se/ansman/kotshi/generators/SealedClassAdapterGenerator.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/generators/SealedClassAdapterGenerator.kt
@@ -31,14 +31,16 @@ import se.ansman.kotshi.nullable
 import javax.lang.model.element.Modifier
 import javax.lang.model.element.TypeElement
 import javax.lang.model.util.Elements
+import javax.lang.model.util.Types
 
 class SealedClassAdapterGenerator(
     classInspector: ClassInspector,
+    types: Types,
     elements: Elements,
     element: TypeElement,
     metadata: ImmutableKmClass,
     globalConfig: GlobalConfig
-) : AdapterGenerator(classInspector, elements, element, metadata, globalConfig) {
+) : AdapterGenerator(classInspector, types, elements, element, metadata, globalConfig) {
     init {
         require(metadata.isSealed)
         if (metadata.typeParameters.isNotEmpty()) {

--- a/tests/src/main/kotlin/se/ansman/kotshi/SealedClassWithExistingLabel.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/SealedClassWithExistingLabel.kt
@@ -1,0 +1,13 @@
+package se.ansman.kotshi
+
+@Polymorphic("type")
+@JsonSerializable
+sealed class SealedClassWithExistingLabel {
+    @PolymorphicLabel("type1")
+    @JsonSerializable
+    object Type1 : SealedClassWithExistingLabel()
+
+    @PolymorphicLabel("type2")
+    @JsonSerializable
+    data class Type2(val name: String, val type: String = "type2") : SealedClassWithExistingLabel()
+}

--- a/tests/src/test/kotlin/se/ansman/kotshi/NestedSealedClassTest.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/NestedSealedClassTest.kt
@@ -25,6 +25,6 @@ class NestedSealedClassTest {
     @Test
     fun nested3() {
         assertEquals(NestedSealedClass.Nested3.NestedChild4("nc4"), adapter.fromJson("""{"type":"nested3","subtype":"nestedChild4","v":"nc4"}"""))
-        assertEquals("""{"subtype":"nestedChild4","v":"nc4"}""", adapter.toJson(NestedSealedClass.Nested3.NestedChild4("nc4")))
+        assertEquals("""{"type":"nested3","subtype":"nestedChild4","v":"nc4"}""", adapter.toJson(NestedSealedClass.Nested3.NestedChild4("nc4")))
     }
 }

--- a/tests/src/test/kotlin/se/ansman/kotshi/NestedSealedClassTest.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/NestedSealedClassTest.kt
@@ -13,18 +13,18 @@ class NestedSealedClassTest {
     @Test
     fun nested1() {
         assertEquals(NestedSealedClass.Nested1.NestedChild1("nc1"), adapter.fromJson("""{"type":"nestedChild1","v":"nc1"}"""))
-        assertEquals("""{"v":"nc1"}""", adapter.toJson(NestedSealedClass.Nested1.NestedChild1("nc1")))
+        assertEquals("""{"type":"nestedChild1","v":"nc1"}""", adapter.toJson(NestedSealedClass.Nested1.NestedChild1("nc1")))
     }
 
     @Test
     fun nested2() {
         assertEquals(NestedSealedClass.Nested1.Nested2.NestedChild2("nc2"), adapter.fromJson("""{"type":"nestedChild2","v":"nc2"}"""))
-        assertEquals("""{"v":"nc2"}""", adapter.toJson(NestedSealedClass.Nested1.NestedChild1("nc2")))
+        assertEquals("""{"type":"nestedChild1","v":"nc2"}""", adapter.toJson(NestedSealedClass.Nested1.NestedChild1("nc2")))
     }
 
     @Test
     fun nested3() {
         assertEquals(NestedSealedClass.Nested3.NestedChild4("nc4"), adapter.fromJson("""{"type":"nested3","subtype":"nestedChild4","v":"nc4"}"""))
-        assertEquals("""{"v":"nc4"}""", adapter.toJson(NestedSealedClass.Nested3.NestedChild4("nc4")))
+        assertEquals("""{"subtype":"nestedChild4","v":"nc4"}""", adapter.toJson(NestedSealedClass.Nested3.NestedChild4("nc4")))
     }
 }

--- a/tests/src/test/kotlin/se/ansman/kotshi/SealedClassWithDefaultWithTypeTest.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/SealedClassWithDefaultWithTypeTest.kt
@@ -24,11 +24,11 @@ class SealedClassWithDefaultWithTypeWithoutTypeTest {
 
     @Test
     fun writing_normal() {
-        assertEquals("""{"bar":"bar2"}""", adapter.toJson(SealedClassWithDefaultWithType.Subclass2("bar2")))
+        assertEquals("""{"type":"type2","bar":"bar2"}""", adapter.toJson(SealedClassWithDefaultWithType.Subclass2("bar2")))
     }
 
     @Test
     fun writing_default() {
-        assertEquals("{}", adapter.toJson(SealedClassWithDefaultWithType.Default))
+        assertEquals("""{"type":"type4"}""", adapter.toJson(SealedClassWithDefaultWithType.Default))
     }
 }

--- a/tests/src/test/kotlin/se/ansman/kotshi/SealedClassWithDefaultWithoutTypeTest.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/SealedClassWithDefaultWithoutTypeTest.kt
@@ -23,7 +23,7 @@ class SealedClassWithDefaultWithoutTypeWithoutTypeTest {
 
     @Test
     fun writing_normal() {
-        assertEquals("""{"bar":"bar2"}""", adapter.toJson(SealedClassWithDefaultWithoutTypeSubclass2("bar2")))
+        assertEquals("""{"type":"type2","bar":"bar2"}""", adapter.toJson(SealedClassWithDefaultWithoutTypeSubclass2("bar2")))
     }
 
     @Test

--- a/tests/src/test/kotlin/se/ansman/kotshi/SealedClassWithExistingLabelTest.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/SealedClassWithExistingLabelTest.kt
@@ -1,0 +1,34 @@
+package se.ansman.kotshi
+
+import com.squareup.moshi.Moshi
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class SealedClassWithExistingLabelTest {
+    private val adapter = Moshi.Builder()
+        .add(TestFactory)
+        .build()
+        .adapter(SealedClassWithExistingLabel::class.java)
+
+    @Test
+    fun reading_normal() {
+        assertEquals(SealedClassWithExistingLabel.Type1, adapter.fromJson("""{"type": "type1"}"""))
+        assertEquals(
+            SealedClassWithExistingLabel.Type2("some name"),
+            adapter.fromJson("""{"type": "type2", "name": "some name"}""")
+        )
+    }
+
+    @Test
+    fun writing_with_label() {
+        assertEquals("""{"type":"type1"}""", adapter.toJson(SealedClassWithExistingLabel.Type1))
+        assertEquals(
+            """{"name":"some name","type":"type2"}""",
+            adapter.toJson(SealedClassWithExistingLabel.Type2(name = "some name", type = "type2"))
+        )
+        assertEquals(
+            """{"name":"some other name","type":"type3"}""",
+            adapter.toJson(SealedClassWithExistingLabel.Type2(name = "some other name", type = "type3"))
+        )
+    }
+}

--- a/tests/src/test/kotlin/se/ansman/kotshi/SealedClassWithoutDefaultTest.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/SealedClassWithoutDefaultTest.kt
@@ -26,7 +26,7 @@ class SealedClassWithoutDefaultTest {
 
     @Test
     fun writing_normal() {
-        assertEquals("""{"bar":"bar2"}""", adapter.toJson(SealedClassWithoutDefault.Subclass2("bar2")))
+        assertEquals("""{"type":"type2","bar":"bar2"}""", adapter.toJson(SealedClassWithoutDefault.Subclass2("bar2")))
     }
 
     @Test


### PR DESCRIPTION
The adapters in Kotshi currently drop the label when serializing, which makes working with `sealed class` hierarchies cumbersome (e.g. cannot use `object` when serializing, must add a `val label: String = "labelKey"` default to data classes). This commit aims to fix this by emitting labels implicitly for sealed classes if they're not already present as a property.

NOTE: this is a pretty big breaking change, maybe this should be a parameter on `@Polymorphic` that defaults to false? E.g. `@Polymorphic(labelKey = "type")` to keep the current behaviour and `@Polymorphic(labelKey = "type", serializeLabels = true)` to get the new one?

---

Example adapter `toJson` function of a `data class`:

```
  @Throws(IOException::class)
  override fun toJson(writer: JsonWriter, value: SealedClassWithDefaultWithType.Subclass1?) {
    if (value == null) {
      writer.nullValue()
      return
    }
    writer.beginObject()
    writer.name("type")
    writer.value("type1")
    writer.name("foo")
    writer.value(value.foo)
    writer.endObject()
  }
```

and an `object`:

```
  @Throws(IOException::class)
  override fun toJson(writer: JsonWriter, value: SealedClassWithDefaultWithType.Default?) {
    if (value == null) {
      writer.nullValue()
    } else {
      writer.beginObject()
      writer.name("type").value("type4")
      writer.endObject()
    }
  }
```