### PR TITLE
Set an explicit java compatibilty

### DIFF
--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -21,6 +21,11 @@ compileTestKotlin {
     }
 }
 
+java {
+    sourceCompatibility = "VERSION_1_8"
+    targetCompatibility = "VERSION_1_8"
+}
+
 dependencies {
     api libraries.kotlin_stdlib
     testImplementation libraries.kotlin_junit


### PR DESCRIPTION
This will ensure the project does not require > Java 8.