### PR TITLE
upgrade libraries and gradle, including kotlin to 1.6

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    api("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
+    api("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0")
     api("org.jetbrains.dokka:dokka-gradle-plugin:1.5.30")
 }
 

--- a/buildSrc/src/main/kotlin/deps.kt
+++ b/buildSrc/src/main/kotlin/deps.kt
@@ -11,7 +11,7 @@ object deps {
     }
 
     object kotlinpoet {
-        const val version = "1.10.1"
+        const val version = "1.10.2"
         const val core = "com.squareup:kotlinpoet:$version"
         const val metadata = "com.squareup:kotlinpoet-metadata:$version"
         const val ksp = "com.squareup:kotlinpoet-ksp:$version"
@@ -31,7 +31,7 @@ object deps {
     }
 
     object ksp {
-        const val version = "1.5.31-1.0.0"
+        const val version = "1.6.0-1.0.1"
         const val api = "com.google.devtools.ksp:symbol-processing-api:$version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
We're using Kotshi in [http4k-connect](https://github.com/http4k/http4k-connect) and are having an issue with upgrading to 1.6 with the existing version of Kotshi due to a clash in Kotlinpoet version. I've upgraded here to 1.6.0 to make sure there's no problem - Kotshi already relies on the new version of poet so that's all cool!

Not sure how close 2.7.0 is to being rolled out but it would be amazing if it was soon! 

Keep up the great work! 😄 