### PR TITLE
Introduce an alternate way of customizing the serialized name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ data class Person(
     val name: String,
     val email: String?,
     val hasVerifiedAccount: Boolean,
-    // This property has a different name in the Json than here so @Json must be applied.
-    @Json(name = "created_at")
+    // This property has a different name in the Json than here so @JsonProperty must be applied.
+    @JsonProperty(name = "created_at")
     val signUpDate: Date,
     // This field has a default value which will be used if the field is missing.
     val jobTitle: String? = null

--- a/api/api/api.api
+++ b/api/api/api.api
@@ -1,7 +1,14 @@
+public abstract interface annotation class se/ansman/kotshi/ExperimentalKotshiApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class se/ansman/kotshi/InternalKotshiApi : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class se/ansman/kotshi/JsonDefaultValue : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class se/ansman/kotshi/JsonProperty : java/lang/annotation/Annotation {
+	public abstract fun name ()Ljava/lang/String;
 }
 
 public abstract interface annotation class se/ansman/kotshi/JsonSerializable : java/lang/annotation/Annotation {

--- a/api/src/main/kotlin/se/ansman/kotshi/ExperimentalKotshiApi.kt
+++ b/api/src/main/kotlin/se/ansman/kotshi/ExperimentalKotshiApi.kt
@@ -1,0 +1,19 @@
+package se.ansman.kotshi
+
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+@MustBeDocumented
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.ANNOTATION_CLASS,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.LOCAL_VARIABLE,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER,
+    AnnotationTarget.TYPEALIAS
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class ExperimentalKotshiApi

--- a/api/src/main/kotlin/se/ansman/kotshi/JsonDefaultValue.kt
+++ b/api/src/main/kotlin/se/ansman/kotshi/JsonDefaultValue.kt
@@ -12,9 +12,9 @@ package se.ansman.kotshi
  * ```
  * @JsonSerializable
  * enum class SomeEnum {
- *     @Json(name = "some-value")
+ *     @JsonProperty(name = "some-value")
  *     SOME_VALUE,
- *     @Json(name = "some-other-value")
+ *     @JsonProperty(name = "some-other-value")
  *     SOME_OTHER_VALUE,
  *     @JsonDefaultValue
  *     UNKNOWN

--- a/api/src/main/kotlin/se/ansman/kotshi/JsonProperty.kt
+++ b/api/src/main/kotlin/se/ansman/kotshi/JsonProperty.kt
@@ -1,0 +1,27 @@
+package se.ansman.kotshi
+
+import com.squareup.moshi.Json
+
+/**
+ * Can be added to a data class property or enum instance to specify the name that is used when serializing it to and
+ * from JSON.
+ *
+ * This is useful when integrating with an API that uses snake_case for example.
+ *
+ * Using this is equivalent to using the [Json] annotation with the benefit that this annotation can be stripped using
+ * code shrinkers because of its retention.
+ *
+ * Example:
+ * ```
+ * @JsonSerializable
+ * data class User(
+ *   @JsonProperty(name = "full_name")
+ *   val fullName: String,
+ * )
+ * ```
+ */
+@Retention(AnnotationRetention.SOURCE)
+@MustBeDocumented
+@Target(AnnotationTarget.FIELD)
+@ExperimentalKotshiApi
+annotation class JsonProperty(val name: String)

--- a/api/src/main/kotlin/se/ansman/kotshi/JsonSerializable.kt
+++ b/api/src/main/kotlin/se/ansman/kotshi/JsonSerializable.kt
@@ -9,6 +9,10 @@ import com.squareup.moshi.JsonWriter
  * Annotation to be placed on classes that Kotshi should generate a [JsonAdapter] for.
  *
  * The annotation should only be placed on Kotlin data classes or Kotlin enums.
+ *
+ * To customize the name of a property when serialized, use the [JsonProperty] annotation on the property or enum
+ * instance;
+ *
  * [JsonQualifier] is supported and so is the [Json] annotation. They can be placed on either the property field or the
  * property parameter.
  *
@@ -22,7 +26,7 @@ import com.squareup.moshi.JsonWriter
  *     @get:JvmName("hasVerifiedAccount") @Getter("hasVerifiedAccount")
  *     val hasVerifiedAccount: Boolean,
  *     // This property has a different name in the Json than here so @Json must be applied
- *     @Json(name = "sign_up_date")
+ *     @JsonProperty(name = "sign_up_date")
  *     val signUpDate: Date,
  *     // This field has a json qualifier applied, the generated adapter will request an adapter with the qualifier.
  *     @NullIfEmpty

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -18,6 +18,11 @@ dependencies {
     api("org.jetbrains.dokka:dokka-gradle-plugin:1.7.10")
 }
 
+tasks.compileJava {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+}
+
 tasks.compileKotlin {
     kotlinOptions {
         jvmTarget = "1.8"

--- a/compiler/src/main/kotlin/se/ansman/kotshi/Types.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/Types.kt
@@ -65,6 +65,8 @@ object Types {
         val internalKotshiApi = ClassName("se.ansman.kotshi", "InternalKotshiApi")
         val namedJsonAdapter = NamedJsonAdapter::class.java.asClassName()
         val jsonDefaultValue = JsonDefaultValue::class.java.asClassName()
+        @OptIn(ExperimentalKotshiApi::class)
+        val jsonProperty = JsonProperty::class.java.asClassName()
     }
 
     object Moshi {

--- a/compiler/src/main/kotlin/se/ansman/kotshi/kapt/KotlinPoetExt.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/kapt/KotlinPoetExt.kt
@@ -13,11 +13,11 @@ import javax.lang.model.element.AnnotationMirror
 fun List<AnnotationSpec>.find(typeName: ClassName): AnnotationSpec? = find { it.typeName == typeName }
 fun List<AnnotationSpec>.has(typeName: ClassName): Boolean = find(typeName) != null
 
-fun List<AnnotationSpec>.jsonName(): String? = find(Types.Moshi.json)?.let { spec ->
-    requireNotNull<AnnotationMirror>(spec.tag()).getValueOrNull("name")
-}
+fun List<AnnotationSpec>.jsonName(): String? =
+    (find(Types.Kotshi.jsonProperty) ?: find(Types.Moshi.json))?.let { spec ->
+        requireNotNull<AnnotationMirror>(spec.tag()).getValueOrNull("name")
+    }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 fun List<AnnotationSpec>.qualifiers(metadataAccessor: MetadataAccessor): Set<AnnotationModel> =
     mapNotNullTo(mutableSetOf()) { spec ->
         val mirror = requireNotNull(spec.tag<AnnotationMirror>())

--- a/compiler/src/main/kotlin/se/ansman/kotshi/ksp/generators/DataClassAdapterGenerator.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/ksp/generators/DataClassAdapterGenerator.kt
@@ -7,6 +7,8 @@ import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.moshi.Json
+import se.ansman.kotshi.ExperimentalKotshiApi
+import se.ansman.kotshi.JsonProperty
 import se.ansman.kotshi.JsonSerializable
 import se.ansman.kotshi.PrimitiveAdapters
 import se.ansman.kotshi.SerializeNulls
@@ -47,6 +49,7 @@ class DataClassAdapterGenerator(
             serializeNulls = serializeNulls,
         )
 
+    @OptIn(ExperimentalKotshiApi::class)
     private fun KSValueParameter.toProperty(): Property {
         val name = name!!.asString()
         val type = type.toTypeName(typeParameterResolver)
@@ -75,8 +78,10 @@ class DataClassAdapterGenerator(
             jsonQualifiers = qualifiers,
             globalConfig = globalConfig,
             useAdaptersForPrimitives = annotation.getEnumValue("useAdaptersForPrimitives", PrimitiveAdapters.DEFAULT),
-            parameterJsonName = getAnnotation<Json>()?.getValue("name"),
-            propertyJsonName = property.getAnnotation<Json>()?.getValue("name"),
+            parameterJsonName = (getAnnotation<JsonProperty>() ?: getAnnotation<Json>())
+                ?.getValue("name"),
+            propertyJsonName = (property.getAnnotation<JsonProperty>() ?: property.getAnnotation<Json>())
+                ?.getValue("name"),
             isTransient = isTransient,
             hasDefaultValue = hasDefault
         )

--- a/compiler/src/main/kotlin/se/ansman/kotshi/ksp/generators/EnumAdapterGenerator.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/ksp/generators/EnumAdapterGenerator.kt
@@ -5,7 +5,9 @@ import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.moshi.Json
+import se.ansman.kotshi.ExperimentalKotshiApi
 import se.ansman.kotshi.JsonDefaultValue
+import se.ansman.kotshi.JsonProperty
 import se.ansman.kotshi.ksp.KspProcessingError
 import se.ansman.kotshi.ksp.getAnnotation
 import se.ansman.kotshi.ksp.getValue
@@ -41,9 +43,12 @@ class EnumAdapterGenerator(
         )
     }
 
+    @OptIn(ExperimentalKotshiApi::class)
     private fun KSClassDeclaration.toEnumEntry(): EnumJsonAdapter.Entry =
         EnumJsonAdapter.Entry(
             name = simpleName.getShortName(),
-            serializedName = getAnnotation<Json>()?.getValue("name") ?: simpleName.getShortName()
+            serializedName = (getAnnotation<JsonProperty>() ?: getAnnotation<Json>())
+                ?.getValue("name")
+                ?: simpleName.getShortName()
         )
 }

--- a/tests/src/main/kotlin/se/ansman/kotshi/CustomNames.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/CustomNames.kt
@@ -2,9 +2,10 @@ package se.ansman.kotshi
 
 import com.squareup.moshi.Json
 
+@OptIn(ExperimentalKotshiApi::class)
 @JsonSerializable
 data class CustomNames(
     @Json(name = "jsonProp1") val prop1: String,
     @field:Json(name = "jsonProp2") val prop2: String,
-    @Json(name = "\"weird\"") val weird: String
+    @JsonProperty(name = "\"weird\"") val weird: String
 )

--- a/tests/src/main/kotlin/se/ansman/kotshi/SomeEnum.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/SomeEnum.kt
@@ -6,8 +6,10 @@ import com.squareup.moshi.Json
 enum class SomeEnum {
     VALUE1,
     VALUE2,
-    @Json(name = "VALUE3-alt")
+    @OptIn(ExperimentalKotshiApi::class)
+    @JsonProperty(name = "VALUE3-alt")
     VALUE3,
+    @Json(name = "VALUE4-alt")
     VALUE4,
     VALUE5
 }

--- a/tests/src/main/kotlin/se/ansman/kotshi/TestClass.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/TestClass.kt
@@ -1,7 +1,5 @@
 package se.ansman.kotshi
 
-import com.squareup.moshi.Json
-
 abstract class SuperClass {
     val someSuperProperty: String = "Hello"
     abstract val abstractProperty: String
@@ -25,7 +23,8 @@ data class TestClass(
     val list: List<String>,
     val nestedList: List<Map<String, Set<String>>>,
     override val abstractProperty: String,
-    @Json(name = "other_name")
+    @OptIn(ExperimentalKotshiApi::class)
+    @JsonProperty(name = "other_name")
     val customName: String,
     @Hello
     val annotated: String,

--- a/tests/src/test/kotlin/se/ansman/kotshi/TestEnums.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/TestEnums.kt
@@ -32,6 +32,7 @@ class TestEnums {
     @Test
     fun customName() {
         assertEquals(SomeEnum.VALUE3, adapter1.fromJson("\"VALUE3-alt\""))
+        assertEquals(SomeEnum.VALUE4, adapter1.fromJson("\"VALUE4-alt\""))
     }
 
     @Test


### PR DESCRIPTION
The new annotation, @JsonProperty, is preferred over @Json because of
its retention. Unlike @Json, @JsonProperty can be stripped at compile
time.

This fixes #175