### PR TITLE
Don't add the @Generated annotation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,41 @@ Examples:
   ```
 </details>
 
+#### `kotshi.generatedAnnotation`
+This option tells Kotshi to add the `@Generated` annotation to all generated classes which is disabled by default.
+
+For Java 9+ use `javax.annotation.processing.Generated` and for Java 8 and below use `javax.annotation.Generated`. 
+
+Examples:
+<details open>
+  <summary>KSP</summary>
+
+  ```kotlin
+  ksp {
+      // When using Java 9 and above
+      arg("kotshi.generatedAnnotation", "javax.annotation.processing.Generated")
+      // When using Java 8 and below
+      arg("kotshi.generatedAnnotation", "javax.annotation.Generated")
+  }
+  ```
+</details>
+
+
+<details>
+  <summary>KAPT</summary>
+
+  ```kotlin
+  kapt {
+      arguments {
+        // When using Java 9 and above
+        arg("kotshi.generatedAnnotation", "javax.annotation.processing.Generated")
+        // When using Java 8 and below
+        arg("kotshi.generatedAnnotation", "javax.annotation.Generated")
+      }
+  }
+  ```
+</details>
+
 ## Limitations
 * Kotshi only processes files written in Kotlin, types written in Java are not supported.
 * Only data classes, enums, sealed classes and objects are supported.

--- a/buildSrc/src/main/kotlin/se/ansman/kotshi/gradle/LibraryPlugin.kt
+++ b/buildSrc/src/main/kotlin/se/ansman/kotshi/gradle/LibraryPlugin.kt
@@ -1,7 +1,9 @@
 package se.ansman.kotshi.gradle
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -13,6 +15,10 @@ abstract class LibraryPlugin : Plugin<Project> {
             task.kotlinOptions {
                 jvmTarget = "1.8"
             }
+        }
+        target.extensions.configure(JavaPluginExtension::class.java) { extension ->
+            extension.sourceCompatibility = JavaVersion.VERSION_1_8
+            extension.targetCompatibility = JavaVersion.VERSION_1_8
         }
 
         target.tasks.withType(JavaCompile::class.java) { task ->

--- a/buildSrc/src/main/kotlin/se/ansman/kotshi/gradle/TestLibraryPlugin.kt
+++ b/buildSrc/src/main/kotlin/se/ansman/kotshi/gradle/TestLibraryPlugin.kt
@@ -1,7 +1,10 @@
 package se.ansman.kotshi.gradle
 
+import deps
+import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -15,6 +18,20 @@ abstract class TestLibraryPlugin : Plugin<Project> {
             }
             getByName("test") {
                 it.java.srcDir(target.rootProject.rootDir.resolve("tests/src/test/kotlin"))
+            }
+        }
+        target.tasks.withType(JavaCompile::class.java) { task ->
+            task.sourceCompatibility = "11"
+            task.targetCompatibility = "11"
+        }
+        target.extensions.configure(JavaPluginExtension::class.java) { extension ->
+            extension.sourceCompatibility = JavaVersion.VERSION_11
+            extension.targetCompatibility = JavaVersion.VERSION_11
+        }
+
+        target.tasks.withType(KotlinCompile::class.java) { task ->
+            task.kotlinOptions {
+                jvmTarget = "11"
             }
         }
 

--- a/compiler/src/main/kotlin/se/ansman/kotshi/Errors.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/Errors.kt
@@ -30,4 +30,6 @@ object Errors {
     fun nonIgnoredDataClassPropertyMustNotBeTransient(propertyName: String) = "Property $propertyName cannot have ignore = false and @Transient"
     fun sealedSubclassMustNotHaveGeneric(typeVariableName: String) = "Could not determine type of type variable $typeVariableName. This can happen when sealed subclasses have type variables that are not present in all superclasses."
     fun multipleFactories(names: List<String>) = "Multiple classes found with annotations @KotshiJsonAdapterFactory: ${names.sorted().joinToString()}"
+    fun invalidGeneratedAnnotation(name: String): String =
+        "Invalid value $name for option ${Options.generatedAnnotation}. Possible values are ${Options.possibleGeneratedAnnotations.keys.joinToString()}"
 }

--- a/compiler/src/main/kotlin/se/ansman/kotshi/KotlinpoetExt.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/KotlinpoetExt.kt
@@ -1,12 +1,11 @@
 package se.ansman.kotshi
 
-import com.google.auto.common.GeneratedAnnotations
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.BYTE
 import com.squareup.kotlinpoet.CHAR
+import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.DOUBLE
-import com.squareup.kotlinpoet.DelicateKotlinPoetApi
 import com.squareup.kotlinpoet.FLOAT
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.INT
@@ -14,10 +13,7 @@ import com.squareup.kotlinpoet.LONG
 import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.asClassName
 import se.ansman.kotshi.kapt.KotshiProcessor
-import javax.lang.model.SourceVersion
-import javax.lang.model.util.Elements
 
 val TypeName.isPrimitive: Boolean
     get() = when (this) {
@@ -35,19 +31,13 @@ val TypeName.isPrimitive: Boolean
 fun TypeName.nullable(): TypeName = if (isNullable) this else copy(nullable = true)
 fun TypeName.notNull(): TypeName = if (isNullable) copy(nullable = false) else this
 
-fun TypeSpec.Builder.maybeAddGeneratedAnnotation(elements: Elements, sourceVersion: SourceVersion) =
-    apply {
-        val typeElement = GeneratedAnnotations.generatedAnnotation(elements, sourceVersion)
-            .orElse(null)
-            ?: return@apply
+fun TypeSpec.Builder.addGeneratedAnnotation(annotationClass: ClassName, processorClass: ClassName) =
         addAnnotation(
-            @OptIn(DelicateKotlinPoetApi::class)
-            AnnotationSpec.builder(typeElement.asClassName())
-                .addMember("%S", KotshiProcessor::class.java.canonicalName)
+            AnnotationSpec.builder(annotationClass)
+                .addMember("%S", processorClass.canonicalName)
                 .addMember("comments = %S", "https://github.com/ansman/kotshi")
                 .build()
         )
-    }
 
 inline fun FunSpec.Builder.addControlFlow(
     controlFlow: String,

--- a/compiler/src/main/kotlin/se/ansman/kotshi/Options.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/Options.kt
@@ -1,0 +1,10 @@
+package se.ansman.kotshi
+
+object Options {
+    const val createAnnotationsUsingConstructor = "kotshi.createAnnotationsUsingConstructor"
+    const val useLegacyDataClassRenderer = "kotshi.useLegacyDataClassRenderer"
+    const val generatedAnnotation = "kotshi.generatedAnnotation"
+
+    val possibleGeneratedAnnotations = setOf(Types.Java.generatedJDK9, Types.Java.generatedPreJDK9)
+        .associateBy { it.canonicalName }
+}

--- a/compiler/src/main/kotlin/se/ansman/kotshi/Types.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/Types.kt
@@ -98,6 +98,8 @@ object Types {
     }
 
     object Java {
+        val generatedJDK9 = ClassName("javax.annotation.processing", "Generated")
+        val generatedPreJDK9 = ClassName("javax.annotation", "Generated")
         val clazz = ClassName("java.lang", "Class")
         val string = ClassName("java.lang", "String")
         val type = Type::class.java.asClassName()

--- a/compiler/src/main/kotlin/se/ansman/kotshi/kapt/AdaptersProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/kapt/AdaptersProcessingStep.kt
@@ -18,11 +18,11 @@ import se.ansman.kotshi.kapt.generators.EnumAdapterGenerator
 import se.ansman.kotshi.kapt.generators.ObjectAdapterGenerator
 import se.ansman.kotshi.kapt.generators.SealedClassAdapterGenerator
 import se.ansman.kotshi.model.GeneratedAdapter
+import se.ansman.kotshi.model.GeneratedAnnotation
 import se.ansman.kotshi.model.GlobalConfig
 import javax.annotation.processing.Filer
 import javax.annotation.processing.Messager
 import javax.annotation.processing.RoundEnvironment
-import javax.lang.model.SourceVersion
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.Modifier
@@ -38,7 +38,7 @@ class AdaptersProcessingStep(
     private val adapters: MutableList<GeneratedAdapter>,
     private val types: Types,
     private val elements: Elements,
-    private val sourceVersion: SourceVersion,
+    private val generatedAnnotation: GeneratedAnnotation?,
     private val createAnnotationsUsingConstructor: Boolean?,
     private val useLegacyDataClassRenderer: Boolean,
 ) : KotshiProcessor.GeneratingProcessingStep() {
@@ -145,7 +145,7 @@ class AdaptersProcessingStep(
                 }
 
                 adapters += generator.generateAdapter(
-                    sourceVersion = sourceVersion,
+                    generatedAnnotation = generatedAnnotation,
                     filer = filer,
                     createAnnotationsUsingConstructor = createAnnotationsUsingConstructor,
                     useLegacyDataClassRenderer = useLegacyDataClassRenderer

--- a/compiler/src/main/kotlin/se/ansman/kotshi/kapt/FactoryProcessingStep.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/kapt/FactoryProcessingStep.kt
@@ -5,6 +5,7 @@ package se.ansman.kotshi.kapt
 import com.google.auto.common.MoreElements
 import com.google.auto.common.MoreTypes
 import com.google.common.collect.SetMultimap
+import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.DelicateKotlinPoetApi
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.asTypeVariableName
@@ -27,8 +28,8 @@ import se.ansman.kotshi.ExperimentalKotshiApi
 import se.ansman.kotshi.KotshiJsonAdapterFactory
 import se.ansman.kotshi.RegisterJsonAdapter
 import se.ansman.kotshi.constructors
-import se.ansman.kotshi.maybeAddGeneratedAnnotation
 import se.ansman.kotshi.model.GeneratedAdapter
+import se.ansman.kotshi.model.GeneratedAnnotation
 import se.ansman.kotshi.model.JsonAdapterFactory
 import se.ansman.kotshi.model.JsonAdapterFactory.Companion.getManualAdapter
 import se.ansman.kotshi.model.RegisteredAdapter
@@ -37,7 +38,6 @@ import se.ansman.kotshi.renderer.JsonAdapterFactoryRenderer
 import javax.annotation.processing.Filer
 import javax.annotation.processing.Messager
 import javax.annotation.processing.RoundEnvironment
-import javax.lang.model.SourceVersion
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.Modifier
@@ -54,7 +54,7 @@ class FactoryProcessingStep(
     override val filer: Filer,
     private val types: Types,
     private val elements: Elements,
-    private val sourceVersion: SourceVersion,
+    private val generatedAnnotation: GeneratedAnnotation?,
     private val generatedAdapters: List<GeneratedAdapter>,
     private val metadataAccessor: MetadataAccessor,
     private val createAnnotationsUsingConstructor: Boolean?,
@@ -105,8 +105,7 @@ class FactoryProcessingStep(
             createAnnotationsUsingConstructor ?: metadataAccessor.getMetadata(element).supportsCreatingAnnotationsWithConstructor
 
         JsonAdapterFactoryRenderer(factory, createAnnotationsUsingConstructor)
-            .render {
-                maybeAddGeneratedAnnotation(elements, sourceVersion)
+            .render(generatedAnnotation) {
                 addOriginatingElement(element)
             }
             .writeTo(filer)

--- a/compiler/src/main/kotlin/se/ansman/kotshi/kapt/Messagers.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/kapt/Messagers.kt
@@ -8,10 +8,10 @@ fun Messager.logKotshiError(error: KaptProcessingError) {
     logKotshiError(error.message, error.element)
 }
 
-fun Messager.logKotshiError(message: String, element: Element) {
+fun Messager.logKotshiError(message: String, element: Element?) {
     printMessage(Diagnostic.Kind.ERROR, "Kotshi: $message", element)
 }
 
-fun Messager.logKotshiWarning(message: String, element: Element) {
+fun Messager.logKotshiWarning(message: String, element: Element?) {
     printMessage(Diagnostic.Kind.WARNING, "Kotshi: $message", element)
 }

--- a/compiler/src/main/kotlin/se/ansman/kotshi/kapt/generators/AdapterGenerator.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/kapt/generators/AdapterGenerator.kt
@@ -20,14 +20,13 @@ import se.ansman.kotshi.getPolymorphicLabels
 import se.ansman.kotshi.kapt.KaptProcessingError
 import se.ansman.kotshi.kapt.MetadataAccessor
 import se.ansman.kotshi.kapt.supportsCreatingAnnotationsWithConstructor
-import se.ansman.kotshi.maybeAddGeneratedAnnotation
 import se.ansman.kotshi.model.GeneratableJsonAdapter
 import se.ansman.kotshi.model.GeneratedAdapter
+import se.ansman.kotshi.model.GeneratedAnnotation
 import se.ansman.kotshi.model.GlobalConfig
 import se.ansman.kotshi.renderer.createRenderer
 import javax.annotation.processing.Filer
 import javax.annotation.processing.Messager
-import javax.lang.model.SourceVersion
 import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
 import javax.lang.model.type.TypeKind
@@ -62,7 +61,7 @@ abstract class AdapterGenerator(
         }
 
     fun generateAdapter(
-        sourceVersion: SourceVersion,
+        generatedAnnotation: GeneratedAnnotation?,
         filer: Filer,
         createAnnotationsUsingConstructor: Boolean?,
         useLegacyDataClassRenderer: Boolean,
@@ -83,9 +82,8 @@ abstract class AdapterGenerator(
                 useLegacyDataClassRenderer = useLegacyDataClassRenderer,
                 error = { KaptProcessingError(it, targetElement) },
             )
-            .render {
+            .render(generatedAnnotation) {
                 addOriginatingElement(targetElement)
-                maybeAddGeneratedAnnotation(elements, sourceVersion)
             }
 
         generatedAdapter.fileSpec.writeTo(filer)

--- a/compiler/src/main/kotlin/se/ansman/kotshi/ksp/KspLoggers.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/ksp/KspLoggers.kt
@@ -7,10 +7,10 @@ fun KSPLogger.logKotshiError(error: KspProcessingError) {
     logKotshiError(error.message, error.node)
 }
 
-fun KSPLogger.logKotshiError(message: String, node: KSNode) {
+fun KSPLogger.logKotshiError(message: String, node: KSNode?) {
     error("Kotshi: $message", node)
 }
 
-fun KSPLogger.logKotshiWarning(message: String, node: KSNode) {
+fun KSPLogger.logKotshiWarning(message: String, node: KSNode?) {
     warn("Kotshi: $message", node)
 }

--- a/compiler/src/main/kotlin/se/ansman/kotshi/model/GeneratedAnnotation.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/model/GeneratedAnnotation.kt
@@ -1,0 +1,15 @@
+package se.ansman.kotshi.model
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+
+data class GeneratedAnnotation(
+    val annotationClass: ClassName,
+    val processorClass: ClassName,
+) {
+    fun toAnnotationSpec(): AnnotationSpec =
+        AnnotationSpec.builder(annotationClass)
+            .addMember("%S", processorClass.canonicalName)
+            .addMember("comments = %S", "https://github.com/ansman/kotshi")
+            .build()
+}

--- a/compiler/src/main/kotlin/se/ansman/kotshi/renderer/AdapterRenderer.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/renderer/AdapterRenderer.kt
@@ -20,6 +20,7 @@ import se.ansman.kotshi.model.DataClassJsonAdapter
 import se.ansman.kotshi.model.EnumJsonAdapter
 import se.ansman.kotshi.model.GeneratableJsonAdapter
 import se.ansman.kotshi.model.GeneratedAdapter
+import se.ansman.kotshi.model.GeneratedAnnotation
 import se.ansman.kotshi.model.ObjectJsonAdapter
 import se.ansman.kotshi.model.SealedClassJsonAdapter
 import se.ansman.kotshi.nullable
@@ -39,7 +40,7 @@ abstract class AdapterRenderer(private val adapter: GeneratableJsonAdapter) {
 
     protected open fun TypeSpec.createProguardRule(): ProguardConfig? = null
 
-    fun render(typeSpecModifier: TypeSpec.Builder.() -> Unit = {}): GeneratedAdapter {
+    fun render(generatedAnnotation: GeneratedAnnotation?, typeSpecModifier: TypeSpec.Builder.() -> Unit = {}): GeneratedAdapter {
         check(!isUsed)
         isUsed = true
         val value = ParameterSpec.builder("value", adapter.targetType.nullable()).build()
@@ -47,6 +48,7 @@ abstract class AdapterRenderer(private val adapter: GeneratableJsonAdapter) {
         val reader = ParameterSpec.builder("reader", Types.Moshi.jsonReader).build()
         val typeSpec = TypeSpec.classBuilder(adapter.adapterName)
             .addModifiers(KModifier.INTERNAL)
+            .apply { generatedAnnotation?.toAnnotationSpec()?.let(::addAnnotation) }
             .addAnnotation(Types.Kotshi.internalKotshiApi)
             .addAnnotation(AnnotationSpec.builder(Types.Kotlin.suppress)
                 // https://github.com/square/moshi/issues/1023

--- a/compiler/src/main/kotlin/se/ansman/kotshi/renderer/JsonAdapterFactoryRenderer.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/renderer/JsonAdapterFactoryRenderer.kt
@@ -22,6 +22,7 @@ import se.ansman.kotshi.addControlFlow
 import se.ansman.kotshi.applyEachIndexed
 import se.ansman.kotshi.hasParameters
 import se.ansman.kotshi.mapTypeArguments
+import se.ansman.kotshi.model.GeneratedAnnotation
 import se.ansman.kotshi.model.JsonAdapterFactory
 import se.ansman.kotshi.model.render
 import se.ansman.kotshi.nullable
@@ -34,7 +35,7 @@ internal class JsonAdapterFactoryRenderer(
 ) {
     private val nameAllocator = NameAllocator()
 
-    fun render(typeSpecModifier: TypeSpec.Builder.() -> Unit): FileSpec {
+    fun render(generatedAnnotation: GeneratedAnnotation?, typeSpecModifier: TypeSpec.Builder.() -> Unit): FileSpec {
         val annotations = mutableSetOf<AnnotationSpec>()
         val properties = mutableSetOf<PropertySpec>()
         val createFunction = makeCreateFunction(
@@ -58,6 +59,7 @@ internal class JsonAdapterFactoryRenderer(
             .addType(
                 TypeSpec.objectBuilder(factory.factoryClassName)
                     .addModifiers(KModifier.INTERNAL)
+                    .apply { generatedAnnotation?.toAnnotationSpec()?.let(::addAnnotation) }
                     .apply {
                         when (factory.usageType) {
                             JsonAdapterFactory.UsageType.Standalone -> addSuperinterface(Types.Moshi.jsonAdapterFactory)

--- a/tests/kapt/src/test/kotlin/se/ansman/kotshi/KaptGeneratorTest.kt
+++ b/tests/kapt/src/test/kotlin/se/ansman/kotshi/KaptGeneratorTest.kt
@@ -4,8 +4,11 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import se.ansman.kotshi.kapt.KotshiProcessor
 
 class KaptGeneratorTest : BaseGeneratorTest() {
-    override fun KotlinCompilation.setUp() {
+    override val processorClassName: String get() = KotshiProcessor::class.java.canonicalName
+
+    override fun KotlinCompilation.setUp(options: Map<String, String>) {
         annotationProcessors = listOf(KotshiProcessor())
+        kaptArgs.putAll(options)
     }
 
     override fun KotlinCompilation.Result.tryLoadClass(name: String): Class<*> = classLoader.loadClass(name)

--- a/tests/ksp/src/test/kotlin/se/ansman/kotshi/KspGeneratorTest.kt
+++ b/tests/ksp/src/test/kotlin/se/ansman/kotshi/KspGeneratorTest.kt
@@ -1,14 +1,24 @@
 package se.ansman.kotshi
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.kspArgs
 import com.tschuchort.compiletesting.kspIncremental
 import com.tschuchort.compiletesting.symbolProcessorProviders
+import se.ansman.kotshi.kapt.KotshiProcessor
+import se.ansman.kotshi.ksp.KotshiSymbolProcessor
 import se.ansman.kotshi.ksp.KotshiSymbolProcessorProvider
+import java.io.File
 
 class KspGeneratorTest : BaseGeneratorTest() {
-    override fun KotlinCompilation.setUp() {
+    override val processorClassName: String get() = KotshiSymbolProcessor::class.java.canonicalName
+
+    override val extraGeneratedFiles: List<File>
+        get() = temporaryFolder.root.resolve("ksp/sources/kotlin/").listFiles()?.asList() ?: emptyList()
+
+    override fun KotlinCompilation.setUp(options: Map<String, String>) {
         kspIncremental = true
         symbolProcessorProviders = listOf(KotshiSymbolProcessorProvider())
+        kspArgs.putAll(options)
     }
 
     // https://github.com/tschuchortdev/kotlin-compile-testing/issues/312


### PR DESCRIPTION
To be able to support KSP as well this feature has been changed to an option that can be used instead.