### PR TITLE
Fix a bug that caused the generated factory to contain warnings

### DIFF
--- a/tests/src/main/kotlin/se/ansman/kotshi/ManuallyRegisteredAdapter.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/ManuallyRegisteredAdapter.kt
@@ -6,11 +6,11 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
-import se.ansman.kotshi.ManuallyRegistedGenericAdapter.GenericType
+import se.ansman.kotshi.ManuallyRegisteredGenericAdapter.GenericType
 import java.lang.reflect.Type
 
 @RegisterJsonAdapter
-object ManuallyRegistedAdapter : JsonAdapter<ManuallyRegistedAdapter.Type>() {
+object ManuallyRegisteredAdapter : JsonAdapter<ManuallyRegisteredAdapter.Type>() {
     override fun fromJson(reader: JsonReader): Type = throw UnsupportedOperationException()
     override fun toJson(writer: JsonWriter, value: Type?) = throw UnsupportedOperationException()
 
@@ -53,7 +53,7 @@ abstract class AbstractAdapter<T> : JsonAdapter<List<T>>() {
 }
 
 @RegisterJsonAdapter
-class ManuallyRegistedGenericAdapter<T : Number>(val types: Array<Type>, val moshi: Moshi) :
+class ManuallyRegisteredGenericAdapter<T : Number>(val types: Array<Type>, val moshi: Moshi) :
     JsonAdapter<GenericType<T>>() {
     override fun fromJson(reader: JsonReader): GenericType<T> = throw UnsupportedOperationException()
     override fun toJson(writer: JsonWriter, value: GenericType<T>?) = throw UnsupportedOperationException()
@@ -64,8 +64,8 @@ class ManuallyRegistedGenericAdapter<T : Number>(val types: Array<Type>, val mos
 
 @OptIn(InternalKotshiApi::class)
 @RegisterJsonAdapter
-class ManuallyRegistedWrappedGenericAdapter :
-    NamedJsonAdapter<ManuallyRegistedWrappedGenericAdapter.GenericType<List<String>>>("Test") {
+class ManuallyRegisteredWrappedGenericAdapter :
+    NamedJsonAdapter<ManuallyRegisteredWrappedGenericAdapter.GenericType<List<String>>>("Test") {
     override fun fromJson(reader: JsonReader): GenericType<List<String>> = throw UnsupportedOperationException()
     override fun toJson(writer: JsonWriter, value: GenericType<List<String>>?) = throw UnsupportedOperationException()
 

--- a/tests/src/test/kotlin/se/ansman/kotshi/ManuallyRegisteredAdapterTest.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/ManuallyRegisteredAdapterTest.kt
@@ -10,15 +10,15 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertSame
 
-class ManuallyRegistedAdapterTest {
+class ManuallyRegisteredAdapterTest {
     private val moshi = Moshi.Builder()
         .add(TestFactory)
         .build()
 
     @Test
     fun testRegistersRegularAdapter() {
-        assertThat(moshi.adapter(ManuallyRegistedAdapter.Type::class.java))
-            .isSameAs(ManuallyRegistedAdapter)
+        assertThat(moshi.adapter(ManuallyRegisteredAdapter.Type::class.java))
+            .isSameAs(ManuallyRegisteredAdapter)
     }
 
     @OptIn(ExperimentalStdlibApi::class)
@@ -57,8 +57,8 @@ class ManuallyRegistedAdapterTest {
     @OptIn(ExperimentalStdlibApi::class)
     @Test
     fun testRegistersGenericAdapter() {
-        val adapter = moshi.adapter<String>(typeOf<ManuallyRegistedGenericAdapter.GenericType<Int>>().javaType)
-        assertIs<ManuallyRegistedGenericAdapter<*>>(adapter)
+        val adapter = moshi.adapter<String>(typeOf<ManuallyRegisteredGenericAdapter.GenericType<Int>>().javaType)
+        assertIs<ManuallyRegisteredGenericAdapter<*>>(adapter)
         assertSame(moshi, adapter.moshi)
         assertThat(adapter.types)
             .asList()
@@ -67,13 +67,13 @@ class ManuallyRegistedAdapterTest {
 
     @OptIn(ExperimentalStdlibApi::class)
     @Test
-    fun testManuallyRegistedWrappedGenericAdapter() {
+    fun testManuallyRegisteredWrappedGenericAdapter() {
         assertFailsWith<IllegalArgumentException> {
-            moshi.adapter<ManuallyRegistedWrappedGenericAdapter.GenericType<List<Int>>>()
+            moshi.adapter<ManuallyRegisteredWrappedGenericAdapter.GenericType<List<Int>>>()
         }
-        assertIs<ManuallyRegistedWrappedGenericAdapter>(
-            moshi.adapter<ManuallyRegistedWrappedGenericAdapter.GenericType<List<String>>>(
-                typeOf<ManuallyRegistedWrappedGenericAdapter.GenericType<List<String>>>().javaType
+        assertIs<ManuallyRegisteredWrappedGenericAdapter>(
+            moshi.adapter<ManuallyRegisteredWrappedGenericAdapter.GenericType<List<String>>>(
+                typeOf<ManuallyRegisteredWrappedGenericAdapter.GenericType<List<String>>>().javaType
             )
         )
     }


### PR DESCRIPTION
If there were no manually registered adapters then there would be an unused variable in the generated factory.

This fixes #192