### PR TITLE
Fix a bug regarding type aliases

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/renderer/DataClassAdapterRenderer.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/renderer/DataClassAdapterRenderer.kt
@@ -193,9 +193,6 @@ class DataClassAdapterRenderer(
                 ++maskNameIndex
             }
         }
-        val constructorPropertyTypes = adapter.properties.map {
-            it.type.asTypeBlock()
-        }
 
         this
             .addStatement(
@@ -373,6 +370,9 @@ class DataClassAdapterRenderer(
                     addComment("Reflectively invoke the synthetic defaults constructor")
                     // Dynamic default constructor call
                     val nonNullConstructorType = constructorProperty.type.copy(nullable = false)
+                    val constructorPropertyTypes = adapter.properties.map {
+                        it.type.unwrapTypeAlias().asTypeBlock()
+                    }
                     val args = constructorPropertyTypes
                         .plus(0.until(maskCount).map { INT_TYPE_BLOCK }) // Masks, one every 32 params
                         .plus(DEFAULT_CONSTRUCTOR_MARKER_TYPE_BLOCK) // Default constructor marker is always last

--- a/tests/src/main/kotlin/se/ansman/kotshi/Issue201.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/Issue201.kt
@@ -1,0 +1,8 @@
+package se.ansman.kotshi
+
+typealias StringList = List<String>
+
+@JsonSerializable
+data class Issue201(
+    val item: StringList? = null
+)


### PR DESCRIPTION
If a data class contained a type alias and default values, then the lookup of the default constructor would contain invalid references to the typealias.

This fixes #201