### PR TITLE
Render field names as names rather than literals so that they're escaped when necessary

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/kotshi/renderer/DataClassAdapterRenderer.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/renderer/DataClassAdapterRenderer.kt
@@ -111,7 +111,7 @@ class DataClassAdapterRenderer(
                 }
                 .applyEach(adapter.serializedProperties) { property ->
                     addCode(".name(%S)", property.jsonName)
-                    val getter = CodeBlock.of("%N.%L", valueParameter, property.name)
+                    val getter = CodeBlock.of("%N.%N", valueParameter, property.name)
 
                     if (property.shouldUseAdapter) {
                         addCode(".%M {\n", Functions.Kotlin.apply)

--- a/compiler/src/main/kotlin/se/ansman/kotshi/renderer/LegacyDataClassAdapterRenderer.kt
+++ b/compiler/src/main/kotlin/se/ansman/kotshi/renderer/LegacyDataClassAdapterRenderer.kt
@@ -70,7 +70,7 @@ class LegacyDataClassAdapterRenderer(
                 }
                 .applyEach(adapter.serializedProperties) { property ->
                     addStatement("%N.name(%S)", writerParameter, property.jsonName)
-                    val getter = CodeBlock.of("%N.%L", valueParameter, property.name)
+                    val getter = CodeBlock.of("%N.%N", valueParameter, property.name)
 
                     if (property.shouldUseAdapter) {
                         addCode(

--- a/tests/src/main/kotlin/se/ansman/kotshi/ClassWithEscapedKotlinKeyword.kt
+++ b/tests/src/main/kotlin/se/ansman/kotshi/ClassWithEscapedKotlinKeyword.kt
@@ -1,0 +1,4 @@
+package se.ansman.kotshi
+
+@JsonSerializable
+data class ClassWithEscapedKotlinKeyword(val `in`: String)

--- a/tests/src/test/kotlin/se/ansman/kotshi/BaseGeneratorTest.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/BaseGeneratorTest.kt
@@ -590,6 +590,20 @@ abstract class BaseGeneratorTest {
         assertThat(result::messages).doesNotContain(Errors.nonDataObject)
     }
 
+    @Test
+    fun `data class can use escaped Kotlin identifiers`() {
+        val result = compile(kotlin("source.kt", """
+            @se.ansman.kotshi.JsonSerializable
+            data class Foo(val `in`: String)
+        """))
+        assertThat(result::exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        val kotshiAdapter = result.tryLoadClass("KotshiFooJsonAdapter")
+        if (kotshiAdapter != null) {
+            assertThat(kotshiAdapter).isAssignableTo(result.classLoader.loadClass("com.squareup.moshi.JsonAdapter"))
+        }
+    }
+
+
     protected fun compile(
         vararg sources: SourceFile,
         options: Map<String, String> = emptyMap(),

--- a/tests/src/test/kotlin/se/ansman/kotshi/TestClassWithEscapedKotlinKeyword.kt
+++ b/tests/src/test/kotlin/se/ansman/kotshi/TestClassWithEscapedKotlinKeyword.kt
@@ -1,0 +1,43 @@
+package se.ansman.kotshi
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.squareup.moshi.JsonWriter
+import okio.Buffer
+import org.junit.jupiter.api.Test
+
+@InternalKotshiApi
+class TestClassWithEscapedKotlinKeyword {
+    private val adapter = KotshiClassWithEscapedKotlinKeywordJsonAdapter()
+
+    @Test
+    fun reading() {
+        val json = """{
+            |  "in": "test"
+            |}""".trimMargin()
+
+        assertThat(adapter.fromJson(json))
+            .isEqualTo(ClassWithEscapedKotlinKeyword("test"))
+    }
+
+    @Test
+    fun writing() {
+        val expected = """{
+            |  "in": "test"
+            |}""".trimMargin()
+
+        val actual = Buffer()
+            .apply {
+                adapter.toJson(
+                    JsonWriter.of(this)
+                        .apply {
+                            indent = "  "
+                        }, ClassWithEscapedKotlinKeyword("test")
+                )
+            }
+            .readUtf8()
+        assertThat(actual)
+            .isEqualTo(expected)
+    }
+
+}


### PR DESCRIPTION
While playing around with Kotshi (which is very nice!) I noticed I couldn't generate an adapter for one class, because it had a field name that it probably shouldn't, `in`.