### PR TITLE
[codex] Harden GitHub workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -15,35 +18,35 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v2
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+    - uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
       with:
         distribution: 'zulu'
         java-version: '21'
-    - uses: gradle/gradle-build-action@v2
+    - uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
       with:
         arguments: check --continue --stacktrace
   testOldestSupportedMoshi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+    - uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
       with:
         distribution: 'zulu'
         java-version: '21'
-    - uses: gradle/gradle-build-action@v2
+    - uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
       with:
         arguments: check --continue --stacktrace -Pkotshi.internal.useLegacyMoshi=true
   deploySnapshot:
     runs-on: ubuntu-latest
     needs: [test, testOldestSupportedMoshi]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+    - uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
       with:
         distribution: 'zulu'
         java-version: '21'
-    - uses: gradle/gradle-build-action@v2
+    - uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
       if: github.ref == 'refs/heads/main'
       with:
         arguments: publishSnapshot --stacktrace

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -16,17 +14,19 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - uses: actions/setup-java@v2
+        uses: actions/configure-pages@b8130d9ab958b325bbde9786d62f2c97a9885a0e # v3
+      - uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
         with:
           distribution: 'zulu'
           java-version: '21'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
         with:
           arguments: :api:dokkaHtml
       - name: Archive
@@ -38,12 +38,15 @@ jobs:
             -cvf ${{ runner.temp }}/artifact.tar \
             .
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: github-pages
           path: ${{ runner.temp }}/artifact.tar
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -52,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@de14547edc9944350dc0481aa5b7afb08e75f254 # v2

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -5,19 +5,22 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: 'zulu'
           java-version: '21'
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v1
+        uses: gradle-update/update-gradle-wrapper-action@0407394b9d173dfc9cf5695f9f560fef6d61a5fe # v1
         with:
           repo-token: ${{ secrets.GRADLE_WRAPPER_UPDATE_TOKEN }}


### PR DESCRIPTION
## Summary

Harden the GitHub Actions workflows against supply-chain and token exposure risks:

- add explicit least-privilege permissions to workflow jobs
- scope GitHub Pages `id-token: write` and `pages: write` to only the deploy job
- pin workflow actions to immutable commit SHAs while preserving the original version tags as comments

## Why

This reduces exposure to the class of attack described in the TanStack npm supply-chain postmortem, where poisoned CI state and broad trusted workflow permissions enabled malicious package publishing.

## Validation

- Parsed all modified workflow YAML files with Ruby's YAML loader
- Scanned workflows for `pull_request_target`, `workflow_run`, floating `@vN` action refs, broad `contents: write`, and unexpected `id-token: write`

`actionlint` is not installed in this environment, so I could not run that additional validation locally.